### PR TITLE
checking for goal, goal placement is dynamic

### DIFF
--- a/config_script.bash
+++ b/config_script.bash
@@ -1,22 +1,40 @@
 #!/bin/bash
 echo "-------------------------------------------------------------"
-echo "viable robots are: [rto-1]"
-echo "viable worlds are: [simple_corridor, maze, maze_simple, maze_simple_2, maze_clutter]"
+echo "TU Many Bots configuration"
 echo "-------------------------------------------------------------"
-if [ -z ${robot_env+x} ]
+echo "tmb_ROBOT_ENV: [simple_corridor, maze, maze_simple, maze_simple_2, maze_clutter]"
+echo "tmb_start_both: [true, false]"
+echo "tmb_publish_perception_logs: [true, false]"
+echo "-------------------------------------------------------------"
+if [ -z ${tmb_ROBOT_ENV+x} ]
 then
   world=simple_corridor
 else
-  world=$robot_env
+  world=$tmb_ROBOT_ENV
+fi
+if [ $tmb_start_both == False ]
+then
+  start_both=$tmb_start_both
+else
+  start_both=True
+fi
+if [ $tmb_publish_perception_logs == True ]
+then
+  publish_perception_logs=True
+else
+  publish_perception_logs=False
 fi
 
 export tmb_ROBOT_ENV=$world
 export tmb_ROBOT=rto-1
 export tmb_ROBOT_BLIND=rto-blind
+export tmb_start_both=$start_both
+export tmb_publish_perception_logs=$publish_perception_logs
+
 
 echo "selected world is: $world"
-echo "selected robot is: rto-1"
-echo "selected blind robot is: rto-blind"
+echo "starting both robots: $start_both"
+echo "publishing perception logs: $publish_perception_logs"
 echo "-------------------------------------------------------------"
 
 if [ $world="simple_corridor" ]
@@ -35,6 +53,10 @@ then
   export tmb_start_robot_blind_y="-3.5"
   export tmb_start_robot_blind_z="0.0"
   export tmb_start_robot_blind_yaw="5.7"
+
+  export tmb_start_goal_x="0.60339"
+  export tmb_start_goal_y="6.06"
+  export tmb_start_goal_yaw="0"
 fi
 if [ $world = "maze" ]
 then
@@ -52,6 +74,10 @@ then
   export tmb_start_robot_blind_y="-9.0"
   export tmb_start_robot_blind_z="0.0"
   export tmb_start_robot_blind_yaw="0.0"
+
+  export tmb_start_goal_x="0"
+  export tmb_start_goal_y="0"
+  export tmb_start_goal_yaw="0"
 fi
 if [ $world = "maze_simple" ]
 then
@@ -69,6 +95,10 @@ then
   export tmb_start_robot_blind_y="-8.0"
   export tmb_start_robot_blind_z="0.0"
   export tmb_start_robot_blind_yaw="0.0"
+
+  export tmb_start_goal_x="-4.60322"
+  export tmb_start_goal_y="6.47698"
+  export tmb_start_goal_yaw="0"
 fi
 if [ $world = "maze_simple_2" ]
 then
@@ -86,6 +116,10 @@ then
   export tmb_start_robot_blind_y="8.0"
   export tmb_start_robot_blind_z="0.0"
   export tmb_start_robot_blind_yaw="0.0"
+
+  export tmb_start_goal_x="4.26245"
+  export tmb_start_goal_y="-9.112855"
+  export tmb_start_goal_yaw="0"
 fi
 if [ $world = "maze_clutter" ]
 then
@@ -103,4 +137,8 @@ then
   export tmb_start_robot_blind_y="8.0"
   export tmb_start_robot_blind_z="0.0"
   export tmb_start_robot_blind_yaw="0.0"
+
+  export tmb_start_goal_x="4.04245"
+  export tmb_start_goal_y="-9.42855"
+  export tmb_start_goal_yaw="0"
 fi

--- a/tmb_communication/launch/explore_robots.launch
+++ b/tmb_communication/launch/explore_robots.launch
@@ -14,7 +14,7 @@
             <param name="min_frontier_size" value="0.5"/>
         </node>
     </group>
-    <group ns="robot2">
+    <group ns="robot2" if="$(env tmb_start_both)">
         <node pkg="explore_lite" type="explore" name="tmb_explorer">
             <param name="robot_base_frame" value="/robot2/base_link"/>
             <param name="costmap_topic" value="/robot2/map"/>

--- a/tmb_communication/launch/move_base.launch
+++ b/tmb_communication/launch/move_base.launch
@@ -13,7 +13,7 @@
 
         </node>
     </group>
-    <group ns="robot2">
+    <group ns="robot2" if="$(env tmb_start_both)">
 
         <!-- Run move_base -->
         <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">

--- a/tmb_communication/launch/multi_map_merge.launch
+++ b/tmb_communication/launch/multi_map_merge.launch
@@ -6,7 +6,7 @@
         <param name="init_pose_yaw" value=" $(env tmb_start_robot1_yaw)"/>
     </group>
 
-    <group ns="robot2/map_merge">
+    <group ns="robot2/map_merge" if="$(env tmb_start_both)">
         <param name="init_pose_x" value=" $(env tmb_start_robot2_x)"/>
         <param name="init_pose_y" value=" $(env tmb_start_robot2_y)"/>
         <param name="init_pose_z" value=" $(env tmb_start_robot2_z)"/>

--- a/tmb_models/objects/Goal/model.sdf
+++ b/tmb_models/objects/Goal/model.sdf
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <sdf version="1.4">
-  <model name="my_model">
+  <model name="goal_cube">
     <pose>0 0 0.5 0 0 0</pose>
     <static>true</static>
     <link name="link">

--- a/tmb_models/worlds/maze_clutter.world
+++ b/tmb_models/worlds/maze_clutter.world
@@ -1981,60 +1981,6 @@
       </link>
       <static>1</static>
     </model>
-    <model name='my_model'>
-      <pose>4.04245 -9.42855 0.5 0 -0 0</pose>
-      <static>1</static>
-      <link name='link'>
-        <inertial>
-          <mass>1</mass>
-          <inertia>
-            <ixx>0.083</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.083</iyy>
-            <iyz>0</iyz>
-            <izz>0.083</izz>
-          </inertia>
-        </inertial>
-        <collision name='collision'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <surface>
-            <contact>
-              <collide_bitmask>1</collide_bitmask>
-              <ode/>
-            </contact>
-            <bounce/>
-            <friction>
-              <torsional>
-                <ode/>
-              </torsional>
-              <ode/>
-            </friction>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='visual'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <material>
-            <ambient>1 0 0 1</ambient>
-            <diffuse>1 0 0 1</diffuse>
-            <specular>0.1 0.1 0.1 1</specular>
-            <emissive>0 0 0 0</emissive>
-          </material>
-        </visual>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-    </model>
     <model name='unit_box'>
       <pose>2.48422 -8.27897 0.5 0 -0 0</pose>
       <link name='link'>
@@ -3007,16 +2953,6 @@
         <scale>1 1 1</scale>
         <link name='link'>
           <pose>0 0 0 0 -0 0</pose>
-          <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>0 0 0 0 -0 0</acceleration>
-          <wrench>0 0 0 0 -0 0</wrench>
-        </link>
-      </model>
-      <model name='my_model'>
-        <pose>4.30339 -9.23312 0.5 0 -0 0</pose>
-        <scale>1 1 1</scale>
-        <link name='link'>
-          <pose>4.30339 -9.23312 0.5 0 -0 0</pose>
           <velocity>0 0 0 0 -0 0</velocity>
           <acceleration>0 0 0 0 -0 0</acceleration>
           <wrench>0 0 0 0 -0 0</wrench>

--- a/tmb_models/worlds/maze_simple.world
+++ b/tmb_models/worlds/maze_simple.world
@@ -1981,60 +1981,6 @@
       </link>
       <static>1</static>
     </model>
-    <model name='my_model'>
-      <pose>-4.60322 6.47698 0.5 0 -0 0</pose>
-      <static>1</static>
-      <link name='link'>
-        <inertial>
-          <mass>1</mass>
-          <inertia>
-            <ixx>0.083</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.083</iyy>
-            <iyz>0</iyz>
-            <izz>0.083</izz>
-          </inertia>
-        </inertial>
-        <collision name='collision'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <surface>
-            <contact>
-              <collide_bitmask>1</collide_bitmask>
-              <ode/>
-            </contact>
-            <bounce/>
-            <friction>
-              <torsional>
-                <ode/>
-              </torsional>
-              <ode/>
-            </friction>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='visual'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <material>
-            <ambient>1 0 0 1</ambient>
-            <diffuse>1 0 0 1</diffuse>
-            <specular>0.1 0.1 0.1 1</specular>
-            <emissive>0 0 0 0</emissive>
-          </material>
-        </visual>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-    </model>
     <state world_name='default'>
       <sim_time>274 382000000</sim_time>
       <real_time>280 660224333</real_time>
@@ -2301,16 +2247,6 @@
         <scale>1 1 1</scale>
         <link name='link'>
           <pose>0 0 0 0 -0 0</pose>
-          <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>0 0 0 0 -0 0</acceleration>
-          <wrench>0 0 0 0 -0 0</wrench>
-        </link>
-      </model>
-      <model name='my_model'>
-        <pose>-4.60322 6.47698 0.5 0 -0 0</pose>
-        <scale>1 1 1</scale>
-        <link name='link'>
-          <pose>-4.60322 6.47698 0.5 0 -0 0</pose>
           <velocity>0 0 0 0 -0 0</velocity>
           <acceleration>0 0 0 0 -0 0</acceleration>
           <wrench>0 0 0 0 -0 0</wrench>

--- a/tmb_models/worlds/maze_simple_2.world
+++ b/tmb_models/worlds/maze_simple_2.world
@@ -1981,60 +1981,6 @@
       </link>
       <static>1</static>
     </model>
-    <model name='my_model'>
-      <pose>4.04245 -9.42855 0.5 0 -0 0</pose>
-      <static>1</static>
-      <link name='link'>
-        <inertial>
-          <mass>1</mass>
-          <inertia>
-            <ixx>0.083</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.083</iyy>
-            <iyz>0</iyz>
-            <izz>0.083</izz>
-          </inertia>
-        </inertial>
-        <collision name='collision'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <surface>
-            <contact>
-              <collide_bitmask>1</collide_bitmask>
-              <ode/>
-            </contact>
-            <bounce/>
-            <friction>
-              <torsional>
-                <ode/>
-              </torsional>
-              <ode/>
-            </friction>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='visual'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <material>
-            <ambient>1 0 0 1</ambient>
-            <diffuse>1 0 0 1</diffuse>
-            <specular>0.1 0.1 0.1 1</specular>
-            <emissive>0 0 0 0</emissive>
-          </material>
-        </visual>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-    </model>
     <model name='unit_box'>
       <pose>2.48422 -8.27897 0.5 0 -0 0</pose>
       <link name='link'>
@@ -3733,16 +3679,6 @@
         <scale>1 1 1</scale>
         <link name='link'>
           <pose>0 0 0 0 -0 0</pose>
-          <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>0 0 0 0 -0 0</acceleration>
-          <wrench>0 0 0 0 -0 0</wrench>
-        </link>
-      </model>
-      <model name='my_model'>
-        <pose>4.30339 -9.23312 0.5 0 -0 0</pose>
-        <scale>1 1 1</scale>
-        <link name='link'>
-          <pose>4.30339 -9.23312 0.5 0 -0 0</pose>
           <velocity>0 0 0 0 -0 0</velocity>
           <acceleration>0 0 0 0 -0 0</acceleration>
           <wrench>0 0 0 0 -0 0</wrench>

--- a/tmb_models/worlds/simple_corridor.world
+++ b/tmb_models/worlds/simple_corridor.world
@@ -87,59 +87,6 @@
       <elevation>0</elevation>
       <heading_deg>0</heading_deg>
     </spherical_coordinates>
-    <model name='unit_box'>
-      <pose>-1.18505 1.46469 0.5 0 -0 0</pose>
-      <link name='link'>
-        <inertial>
-          <mass>1</mass>
-          <inertia>
-            <ixx>0.166667</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.166667</iyy>
-            <iyz>0</iyz>
-            <izz>0.166667</izz>
-          </inertia>
-          <pose>0 0 0 0 -0 0</pose>
-        </inertial>
-        <collision name='collision'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <bounce/>
-            <friction>
-              <torsional>
-                <ode/>
-              </torsional>
-              <ode/>
-            </friction>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='visual'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <material>
-            <script>
-              <name>Gazebo/Grey</name>
-              <uri>file://media/materials/scripts/gazebo.material</uri>
-            </script>
-          </material>
-        </visual>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-    </model>
     <model name='unit_box_clone'>
       <pose>-0.170822 1.46764 0.5 0 -0 0</pose>
       <link name='link'>
@@ -1412,326 +1359,8 @@
         <kinematic>0</kinematic>
       </link>
     </model>
-    <model name='unit_box_clone_25'>
-      <pose>-3.24967 -1.51741 0.5 0 -0 0</pose>
-      <link name='link'>
-        <inertial>
-          <mass>1</mass>
-          <inertia>
-            <ixx>0.166667</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.166667</iyy>
-            <iyz>0</iyz>
-            <izz>0.166667</izz>
-          </inertia>
-          <pose>0 0 0 0 -0 0</pose>
-        </inertial>
-        <collision name='collision'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <bounce/>
-            <friction>
-              <torsional>
-                <ode/>
-              </torsional>
-              <ode/>
-            </friction>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='visual'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <material>
-            <script>
-              <name>Gazebo/Grey</name>
-              <uri>file://media/materials/scripts/gazebo.material</uri>
-            </script>
-          </material>
-        </visual>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-    </model>
-    <model name='unit_box_clone_26'>
-      <pose>-3.23115 -0.604262 0.5 0 -0 0</pose>
-      <link name='link'>
-        <inertial>
-          <mass>1</mass>
-          <inertia>
-            <ixx>0.166667</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.166667</iyy>
-            <iyz>0</iyz>
-            <izz>0.166667</izz>
-          </inertia>
-          <pose>0 0 0 0 -0 0</pose>
-        </inertial>
-        <collision name='collision'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <bounce/>
-            <friction>
-              <torsional>
-                <ode/>
-              </torsional>
-              <ode/>
-            </friction>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='visual'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <material>
-            <script>
-              <name>Gazebo/Grey</name>
-              <uri>file://media/materials/scripts/gazebo.material</uri>
-            </script>
-          </material>
-        </visual>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-    </model>
-    <model name='unit_box_clone_27'>
-      <pose>-3.23168 0.340398 0.5 0 -0 0</pose>
-      <link name='link'>
-        <inertial>
-          <mass>1</mass>
-          <inertia>
-            <ixx>0.166667</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.166667</iyy>
-            <iyz>0</iyz>
-            <izz>0.166667</izz>
-          </inertia>
-          <pose>0 0 0 0 -0 0</pose>
-        </inertial>
-        <collision name='collision'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <bounce/>
-            <friction>
-              <torsional>
-                <ode/>
-              </torsional>
-              <ode/>
-            </friction>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='visual'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <material>
-            <script>
-              <name>Gazebo/Grey</name>
-              <uri>file://media/materials/scripts/gazebo.material</uri>
-            </script>
-          </material>
-        </visual>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-    </model>
-    <model name='unit_box_clone_28'>
-      <pose>-3.17535 1.23924 0.5 0 -0 0</pose>
-      <link name='link'>
-        <inertial>
-          <mass>1</mass>
-          <inertia>
-            <ixx>0.166667</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.166667</iyy>
-            <iyz>0</iyz>
-            <izz>0.166667</izz>
-          </inertia>
-          <pose>0 0 0 0 -0 0</pose>
-        </inertial>
-        <collision name='collision'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <bounce/>
-            <friction>
-              <torsional>
-                <ode/>
-              </torsional>
-              <ode/>
-            </friction>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='visual'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <material>
-            <script>
-              <name>Gazebo/Grey</name>
-              <uri>file://media/materials/scripts/gazebo.material</uri>
-            </script>
-          </material>
-        </visual>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-    </model>
     <model name='unit_box_clone_29'>
       <pose>-2.10324 1.37282 0.5 0 -0 0</pose>
-      <link name='link'>
-        <inertial>
-          <mass>1</mass>
-          <inertia>
-            <ixx>0.166667</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.166667</iyy>
-            <iyz>0</iyz>
-            <izz>0.166667</izz>
-          </inertia>
-          <pose>0 0 0 0 -0 0</pose>
-        </inertial>
-        <collision name='collision'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <bounce/>
-            <friction>
-              <torsional>
-                <ode/>
-              </torsional>
-              <ode/>
-            </friction>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='visual'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <material>
-            <script>
-              <name>Gazebo/Grey</name>
-              <uri>file://media/materials/scripts/gazebo.material</uri>
-            </script>
-          </material>
-        </visual>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-    </model>
-    <model name='unit_box_clone_31'>
-      <pose>2.85441 6.31237 0.5 0 -0 0</pose>
-      <link name='link'>
-        <inertial>
-          <mass>1</mass>
-          <inertia>
-            <ixx>0.166667</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.166667</iyy>
-            <iyz>0</iyz>
-            <izz>0.166667</izz>
-          </inertia>
-          <pose>0 0 0 0 -0 0</pose>
-        </inertial>
-        <collision name='collision'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <bounce/>
-            <friction>
-              <torsional>
-                <ode/>
-              </torsional>
-              <ode/>
-            </friction>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='visual'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <material>
-            <script>
-              <name>Gazebo/Grey</name>
-              <uri>file://media/materials/scripts/gazebo.material</uri>
-            </script>
-          </material>
-        </visual>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-    </model>
-    <model name='unit_box_clone_32'>
-      <pose>3.8975 6.2935 0.5 0 -0 0</pose>
       <link name='link'>
         <inertial>
           <mass>1</mass>
@@ -1836,112 +1465,6 @@
         <kinematic>0</kinematic>
       </link>
     </model>
-    <model name='unit_box_clone_34'>
-      <pose>1.93567 6.33139 0.5 0 -0 0</pose>
-      <link name='link'>
-        <inertial>
-          <mass>1</mass>
-          <inertia>
-            <ixx>0.166667</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.166667</iyy>
-            <iyz>0</iyz>
-            <izz>0.166667</izz>
-          </inertia>
-          <pose>0 0 0 0 -0 0</pose>
-        </inertial>
-        <collision name='collision'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <bounce/>
-            <friction>
-              <torsional>
-                <ode/>
-              </torsional>
-              <ode/>
-            </friction>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='visual'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <material>
-            <script>
-              <name>Gazebo/Grey</name>
-              <uri>file://media/materials/scripts/gazebo.material</uri>
-            </script>
-          </material>
-        </visual>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-    </model>
-    <model name='unit_box_clone_30_clone'>
-      <pose>1.03249 6.39483 0.5 0 -0 0</pose>
-      <link name='link'>
-        <inertial>
-          <mass>1</mass>
-          <inertia>
-            <ixx>0.166667</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.166667</iyy>
-            <iyz>0</iyz>
-            <izz>0.166667</izz>
-          </inertia>
-          <pose>0 0 0 0 -0 0</pose>
-        </inertial>
-        <collision name='collision'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <bounce/>
-            <friction>
-              <torsional>
-                <ode/>
-              </torsional>
-              <ode/>
-            </friction>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='visual'>
-          <geometry>
-            <box>
-              <size>1 1 1</size>
-            </box>
-          </geometry>
-          <material>
-            <script>
-              <name>Gazebo/Grey</name>
-              <uri>file://media/materials/scripts/gazebo.material</uri>
-            </script>
-          </material>
-        </visual>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-    </model>
     <model name='unit_box_clone_30_clone_0'>
       <pose>0.957784 4.2158 0.5 0 -0 0</pose>
       <link name='link'>
@@ -1995,4123 +1518,11 @@
         <kinematic>0</kinematic>
       </link>
     </model>
-    <model name='r2_clone'>
-      <link name='/r2/robot_world'>
-        <pose>0 0 0 0 -0 0</pose>
-        <inertial>
-          <pose>0 0 0.625017 0 -0 0</pose>
-          <mass>56.01</mass>
-          <inertia>
-            <ixx>14.6261</ixx>
-            <ixy>-3.58342e-06</ixy>
-            <ixz>-5.7072e-09</ixz>
-            <iyy>14.6252</iyy>
-            <iyz>-1.43337e-06</iyz>
-            <izz>12.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/robot_world_collision_/r2/baseplate'>
-          <pose>0 0 0 1.57 0 3.14</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Stanchion_Baseplate.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <bounce/>
-            <friction>
-              <torsional>
-                <ode/>
-              </torsional>
-              <ode/>
-            </friction>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <collision name='/r2/robot_world_collision_/r2/stanchion'>
-          <pose>0 0 0.4 0 -0 -1.57319</pose>
-          <geometry>
-            <cylinder>
-              <length>0.5</length>
-              <radius>0.075</radius>
-            </cylinder>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <bounce/>
-            <friction>
-              <torsional>
-                <ode/>
-              </torsional>
-              <ode/>
-            </friction>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/robot_world_visual_/r2/baseplate'>
-          <pose>0 0 0 1.57 0 3.14</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Stanchion_Baseplate.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <visual name='/r2/robot_world_visual_/r2/stanchion'>
-          <pose>0 0 0.7 0 -0 -1.57319</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Stanchion.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <link name='/r2/waist_center'>
-        <pose>0 0 0.72 -3.14159 0.001593 -1.57478</pose>
-        <inertial>
-          <pose>2.3e-05 0 -0.00027 0 -0 0</pose>
-          <mass>20.13</mass>
-          <inertia>
-            <ixx>2.00426</ixx>
-            <ixy>0</ixy>
-            <ixz>-0.000355745</ixz>
-            <iyy>2.00716</iyy>
-            <iyz>0</iyz>
-            <izz>2.0042</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/waist_center_collision'>
-          <pose>0.02 0.05 -0.5625 -1.57 -0 -1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Body.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <collision name='/r2/waist_center_collision_/r2/backpack'>
-          <pose>0 0 -0.54 0 -0 0.25</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Backpack.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <collision name='/r2/waist_center_collision_/r2/body_cover'>
-          <pose>0.02 0.05 -0.5625 -1.57 -0 -1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Body_Cover.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/waist_center_visual'>
-          <pose>0.02 0.05 -0.5625 -1.57 -0 -1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Body.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <visual name='/r2/waist_center_visual_/r2/backpack'>
-          <pose>0 0 -0.54 0 -0 0.25</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Backpack.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <visual name='/r2/waist_center_visual_/r2/body_cover'>
-          <pose>0.02 0.05 -0.5625 -1.57 -0 -1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Body_Cover.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/waist/joint0' type='revolute'>
-        <child>/r2/waist_center</child>
-        <parent>/r2/robot_world</parent>
-        <axis>
-          <xyz expressed_in='__model__'>6e-06 0.001593 -0.999999</xyz>
-          <limit>
-            <lower>-3.14</lower>
-            <upper>3.14</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>10</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/left_shoulder_roll'>
-        <pose>0.000257 0.064475 1.26435 1.5756 -0.001539 1.30542</pose>
-        <inertial>
-          <pose>-0.008992 -0.001316 0.10287 0 -0 0</pose>
-          <mass>6.16886</mass>
-          <inertia>
-            <ixx>0.0198585</ixx>
-            <ixy>-0.0060196</ixy>
-            <ixz>-0.000395063</ixz>
-            <iyy>0.0671901</iyy>
-            <iyz>0.00012683</iyz>
-            <izz>0.063415</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_shoulder_roll_collision'>
-          <pose>0 0 0.08 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Shoulder_Upper.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_shoulder_roll_visual'>
-          <pose>0 0 0.08 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Shoulder_Upper.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/joint0' type='revolute'>
-        <child>/r2/left_shoulder_roll</child>
-        <parent>/r2/waist_center</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.964985 -0.262261 -0.004808</xyz>
-          <limit>
-            <lower>-1.57</lower>
-            <upper>1.57</upper>
-            <effort>100</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>10</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/left_shoulder_pitch'>
-        <pose>0.305782 -0.01856 1.26283 1.88114 -1.56575 -0.575018</pose>
-        <inertial>
-          <pose>0.037084 -0.000284 0.007798 0 -0 0</pose>
-          <mass>4.42706</mass>
-          <inertia>
-            <ixx>0.0270106</ixx>
-            <ixy>0.00151295</ixy>
-            <ixz>-5.23825e-05</ixz>
-            <iyy>0.0113837</iyy>
-            <iyz>2.17139e-05</iyz>
-            <izz>0.0251963</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_shoulder_pitch_collision'>
-          <pose>0 0 0 0 0 -1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Shoulder_Lower.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_shoulder_pitch_visual'>
-          <pose>0 0 0 0 0 -1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Shoulder_Lower.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/joint1' type='revolute'>
-        <child>/r2/left_shoulder_pitch</child>
-        <parent>/r2/left_shoulder_roll</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.261598 -0.965176 -0.001542</xyz>
-          <limit>
-            <lower>-1.66</lower>
-            <upper>0.175</upper>
-            <effort>100</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>10</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/left_upper_arm'>
-        <pose>0.305782 -0.01856 1.26283 -2.83205 -1.56575 -0.575018</pose>
-        <inertial>
-          <pose>-0.007417 -0.041402 0.1016 0 -0 0</pose>
-          <mass>4.85344</mass>
-          <inertia>
-            <ixx>0.0160074</ixx>
-            <ixy>-0.00339462</ixy>
-            <ixz>0.00658439</ixz>
-            <iyy>0.0462371</iyy>
-            <iyz>0.00137541</iyz>
-            <izz>0.0421401</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_upper_arm_collision'>
-          <pose>0 0 0.1016 0 -0 3.14</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Upper_Arm.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_upper_arm_visual'>
-          <pose>0 0 0.1016 0 -0 3.14</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Upper_Arm.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/joint2' type='revolute'>
-        <child>/r2/left_upper_arm</child>
-        <parent>/r2/left_shoulder_pitch</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.964959 -0.262357 -0.004808</xyz>
-          <limit>
-            <lower>-4.89</lower>
-            <upper>-0.79</upper>
-            <effort>100</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>10</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/left_elbow'>
-        <pose>0.649499 -0.111925 1.20674 1.87634 -1.56575 -0.575018</pose>
-        <inertial>
-          <pose>0.026162 0.033782 0.015443 0 -0 0</pose>
-          <mass>2.97103</mass>
-          <inertia>
-            <ixx>0.0120275</ixx>
-            <ixy>0.00164171</ixy>
-            <ixz>-0.00118812</ixz>
-            <iyy>0.00883772</iyy>
-            <iyz>0.00316051</iyz>
-            <izz>0.010535</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_elbow_collision'>
-          <pose>0 0 0 0 0 -1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Elbow.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_elbow_visual'>
-          <pose>0 0 0 0 0 -1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Elbow.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/joint3' type='revolute'>
-        <child>/r2/left_elbow</child>
-        <parent>/r2/left_upper_arm</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.266228 -0.963909 -0.001518</xyz>
-          <limit>
-            <lower>-2.79</lower>
-            <upper>-0.087</upper>
-            <effort>100</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/left_lower_arm'>
-        <pose>0.649728 -0.112073 1.26077 -2.83305 -1.56575 -0.575018</pose>
-        <inertial>
-          <pose>0.000356 -0.001227 0.17653 0 -0 0</pose>
-          <mass>6.93996</mass>
-          <inertia>
-            <ixx>0.012525</ixx>
-            <ixy>-0.000244647</ixy>
-            <ixz>0.000520899</ixz>
-            <iyy>0.0395064</iyy>
-            <iyz>-0.000169146</iyz>
-            <izz>0.0403843</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_lower_arm_collision'>
-          <pose>0 0 0.1 0 -0 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Forearm.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_lower_arm_visual'>
-          <pose>0 0 0.1 0 -0 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Forearm.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/joint4' type='revolute'>
-        <child>/r2/left_lower_arm</child>
-        <parent>/r2/left_elbow</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.964696 -0.263322 -0.00481</xyz>
-          <limit>
-            <lower>-1.3</lower>
-            <upper>4.45</upper>
-            <effort>100</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/left_wrist_pitch'>
-        <pose>0.994171 -0.206092 1.25906 1.85494 -1.56575 -0.575018</pose>
-        <inertial>
-          <pose>-0.004064 0 -0.000922 0 -0 0</pose>
-          <mass>0.116573</mass>
-          <inertia>
-            <ixx>5.765e-05</ixx>
-            <ixy>4.36e-11</ixy>
-            <ixz>1.75876e-06</ixz>
-            <iyy>1.69438e-05</iyy>
-            <iyz>5.4431e-08</iyz>
-            <izz>4.41886e-05</izz>
-          </inertia>
-        </inertial>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/joint5' type='revolute'>
-        <child>/r2/left_wrist_pitch</child>
-        <parent>/r2/left_lower_arm</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.286793 -0.957991 -0.001415</xyz>
-          <limit>
-            <lower>-1.22</lower>
-            <upper>1.22</upper>
-            <effort>100</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/left_wrist_yaw'>
-        <pose>0.999988 -0.207833 1.25901 -3.06047 0.006749 -0.290868</pose>
-        <inertial>
-          <pose>0.033205 -0.025812 0.033286 0 -0 0</pose>
-          <mass>2.37882</mass>
-          <inertia>
-            <ixx>0.0112391</ixx>
-            <ixy>0.000520047</ixy>
-            <ixz>0.00298821</ixz>
-            <iyy>0.0135826</iyy>
-            <iyz>0.000437366</iyz>
-            <izz>0.0112115</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_wrist_yaw_collision_/r2/left_palm'>
-          <pose>0 0 0 3.14 -0 1.556</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Palm.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-            </friction>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_wrist_yaw_visual_/r2/left_palm'>
-          <pose>0 0 0 3.14 -0 1.556</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Palm.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/joint6' type='revolute'>
-        <child>/r2/left_wrist_yaw</child>
-        <parent>/r2/left_wrist_pitch</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.016794 0.079555 -0.996689</xyz>
-          <limit>
-            <lower>-0.785</lower>
-            <upper>0.785</upper>
-            <effort>100</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/left_index_yaw'>
-        <pose>1.08724 -0.263526 1.27225 -3.0619 0.016574 -0.412654</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.001</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/index/joint0' type='revolute'>
-        <child>/r2/left_index_yaw</child>
-        <parent>/r2/left_wrist_yaw</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.016794 0.079555 -0.996689</xyz>
-          <limit>
-            <lower>-0.3491</lower>
-            <upper>0.3491</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_index_proximal'>
-        <pose>1.09608 -0.267396 1.27209 -1.4911 0.016574 -0.412654</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.001</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_index_proximal_collision'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_index_proximal_visual'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/index/joint1' type='revolute'>
-        <child>/r2/left_index_proximal</child>
-        <parent>/r2/left_index_yaw</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.400978 0.912623 0.079601</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.57</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_index_medial'>
-        <pose>1.13679 -0.28522 1.27135 -1.4911 0.016574 -0.412654</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.001</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_index_medial_collision'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Mid.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_index_medial_visual'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Mid.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/index/joint2' type='revolute'>
-        <child>/r2/left_index_medial</child>
-        <parent>/r2/left_index_proximal</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.400978 0.912623 0.079601</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.57</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_index_distal'>
-        <pose>1.16471 -0.297442 1.27085 -1.4911 0.016574 -0.412654</pose>
-        <inertial>
-          <pose>0.012319 0 0 0 -0 0</pose>
-          <mass>0.002</mass>
-          <inertia>
-            <ixx>0.002</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.0020003</iyy>
-            <iyz>0</iyz>
-            <izz>0.0020003</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_index_distal_collision'>
-          <pose>0 0 0 0 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Dist.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_index_distal_visual'>
-          <pose>0 0 0 0 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Dist.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/index/joint3' type='revolute'>
-        <child>/r2/left_index_distal</child>
-        <parent>/r2/left_index_medial</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.400978 0.912623 0.079601</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.57</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_middle_yaw'>
-        <pose>1.10098 -0.242075 1.27419 -3.06047 0.006749 -0.290868</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.001</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/middle/joint0' type='revolute'>
-        <child>/r2/left_middle_yaw</child>
-        <parent>/r2/left_wrist_yaw</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.016794 0.079555 -0.996689</xyz>
-          <limit>
-            <lower>-0.3491</lower>
-            <upper>0.3491</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_middle_proximal'>
-        <pose>1.11023 -0.244843 1.27413 -1.48968 0.006749 -0.290868</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.001</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_middle_proximal_collision'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_middle_proximal_visual'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/middle/joint1' type='revolute'>
-        <child>/r2/left_middle_proximal</child>
-        <parent>/r2/left_middle_yaw</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.286365 0.954688 0.081028</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.57</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_middle_medial'>
-        <pose>1.15281 -0.25759 1.27383 -1.48968 0.006749 -0.290868</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.001</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_middle_medial_collision'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Mid.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_middle_medial_visual'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Mid.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/middle/joint2' type='revolute'>
-        <child>/r2/left_middle_medial</child>
-        <parent>/r2/left_middle_proximal</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.286365 0.954688 0.081028</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.57</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_middle_distal'>
-        <pose>1.18201 -0.266331 1.27362 -1.48968 0.006749 -0.290868</pose>
-        <inertial>
-          <pose>0.012319 0 0 0 -0 0</pose>
-          <mass>0.002</mass>
-          <inertia>
-            <ixx>0.002</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.0020003</iyy>
-            <iyz>0</iyz>
-            <izz>0.0020003</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_middle_distal_collision'>
-          <pose>0 0 0 0 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Dist.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_middle_distal_visual'>
-          <pose>0 0 0 0 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Dist.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/middle/joint3' type='revolute'>
-        <child>/r2/left_middle_distal</child>
-        <parent>/r2/left_middle_medial</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.286365 0.954688 0.081028</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.57</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_little_proximal'>
-        <pose>1.10211 -0.196907 1.26772 -1.45457 0.079556 -0.109831</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.001</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_little_proximal_collision'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_little_proximal_visual'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/little/joint0' type='revolute'>
-        <child>/r2/left_little_proximal</child>
-        <parent>/r2/left_wrist_yaw</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.118031 0.986259 0.115594</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>2.9671</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_little_medial'>
-        <pose>1.14615 -0.201764 1.26418 -1.45457 0.079556 -0.109831</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.001</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_little_medial_collision'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Mid.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_little_medial_visual'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Mid.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/little/joint1' type='revolute'>
-        <child>/r2/left_little_medial</child>
-        <parent>/r2/left_little_proximal</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.118031 0.986259 0.115594</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>2.9671</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_little_distal'>
-        <pose>1.17635 -0.205094 1.26176 -1.45457 0.079556 -0.109831</pose>
-        <inertial>
-          <pose>0.012319 0 0 0 -0 0</pose>
-          <mass>0.002</mass>
-          <inertia>
-            <ixx>0.002</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.0020003</iyy>
-            <iyz>0</iyz>
-            <izz>0.0020003</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_little_distal_collision'>
-          <pose>0 0 0 0 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Dist.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_little_distal_visual'>
-          <pose>0 0 0 0 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Dist.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/little/joint2' type='revolute'>
-        <child>/r2/left_little_distal</child>
-        <parent>/r2/left_little_medial</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.118031 0.986259 0.115594</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>2.9671</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_ring_proximal'>
-        <pose>1.10934 -0.221045 1.27216 -1.48946 -0.003176 -0.169099</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.001</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_ring_proximal_collision'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_ring_proximal_visual'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/ring/joint0' type='revolute'>
-        <child>/r2/left_ring_proximal</child>
-        <parent>/r2/left_wrist_yaw</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.167483 0.982521 0.081247</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>2.9671</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_ring_medial'>
-        <pose>1.15316 -0.228525 1.2723 -1.48946 -0.003176 -0.169099</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.001</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_ring_medial_collision'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Mid.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_ring_medial_visual'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Mid.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/ring/joint1' type='revolute'>
-        <child>/r2/left_ring_medial</child>
-        <parent>/r2/left_ring_proximal</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.167483 0.982521 0.081247</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>2.9671</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_ring_distal'>
-        <pose>1.1832 -0.233655 1.2724 -1.48946 -0.003176 -0.169099</pose>
-        <inertial>
-          <pose>0.012319 0 0 0 -0 0</pose>
-          <mass>0.002</mass>
-          <inertia>
-            <ixx>0.002</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.0020003</iyy>
-            <iyz>0</iyz>
-            <izz>0.0020003</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_ring_distal_collision'>
-          <pose>0 0 0 0 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Dist.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_ring_distal_visual'>
-          <pose>0 0 0 0 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Dist.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/ring/joint2' type='revolute'>
-        <child>/r2/left_ring_distal</child>
-        <parent>/r2/left_ring_medial</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.167483 0.982521 0.081247</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>2.9671</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_thumb_base'>
-        <pose>1.023 -0.245896 1.24999 1.5853 0.0801 -1.59956</pose>
-        <inertial>
-          <pose>0.000234 0 0 0 -0 0</pose>
-          <mass>0.051</mass>
-          <inertia>
-            <ixx>0.002</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.00200014</iyy>
-            <iyz>-5.16988e-26</iyz>
-            <izz>0.00200014</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_thumb_base_collision_/r2/left_thumb_proximal'>
-          <pose>0.001938 0 0 -3.1408 0 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Thumb_Carp.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_thumb_base_visual_/r2/left_thumb_proximal'>
-          <pose>0.001938 0 0 -3.1408 0 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Thumb_Carp.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/thumb/joint0' type='revolute'>
-        <child>/r2/left_thumb_base</child>
-        <parent>/r2/left_wrist_yaw</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.999448 0.029915 -0.014452</xyz>
-          <limit>
-            <lower>-1.2217</lower>
-            <upper>0</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_thumb_medial_prime'>
-        <pose>1.02266 -0.257791 1.24904 0.0145 0.0801 -1.59956</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.001</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_thumb_medial_prime_collision'>
-          <pose>0 0 0 -1.57 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Thumb_MtCar.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_thumb_medial_prime_visual'>
-          <pose>-0 0 0 -1.57 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Thumb_MtCar.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/thumb/joint1' type='revolute'>
-        <child>/r2/left_thumb_medial_prime</child>
-        <parent>/r2/left_thumb_base</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.016794 -0.079555 0.996689</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.3963</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_thumb_medial'>
-        <pose>1.01983 -0.288559 1.24908 -0.683633 0.080099 -1.59956</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.001</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_thumb_medial_collision'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Thumb_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_thumb_medial_visual'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Thumb_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/thumb/joint2' type='revolute'>
-        <child>/r2/left_thumb_medial</child>
-        <parent>/r2/left_thumb_medial_prime</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.629568 -0.080172 0.772798</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.2217</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/left_thumb_distal'>
-        <pose>1.0187 -0.327786 1.24593 -0.683633 0.080099 -1.59956</pose>
-        <inertial>
-          <pose>0.01651 0 0 0 -0 0</pose>
-          <mass>0.002</mass>
-          <inertia>
-            <ixx>0.002</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.00200055</iyy>
-            <iyz>0</iyz>
-            <izz>0.00200055</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/left_thumb_distal_collision'>
-          <pose>0 0 0 -0.001593 0.001593 3.14159</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Thumb_Dist.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/left_thumb_distal_visual'>
-          <pose>0 0 0 -0.001593 0.001593 3.14159</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Thumb_Dist.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/left_arm/hand/thumb/joint3' type='revolute'>
-        <child>/r2/left_thumb_distal</child>
-        <parent>/r2/left_thumb_medial</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.629568 -0.080172 0.772798</xyz>
-          <limit>
-            <lower>-0.5236</lower>
-            <upper>1.57</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_shoulder_roll'>
-        <pose>0.000257 0.064475 1.26435 1.5824 0.001538 -1.31321</pose>
-        <inertial>
-          <pose>0.008992 -0.001316 0.10287 0 -0 0</pose>
-          <mass>6.16886</mass>
-          <inertia>
-            <ixx>0.0198585</ixx>
-            <ixy>0.0060196</ixy>
-            <ixz>0.000395063</ixz>
-            <iyy>0.0671901</iyy>
-            <iyz>0.00012683</iyz>
-            <izz>0.063415</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_shoulder_roll_collision'>
-          <pose>0 0 0.0254 0 -0 2.35</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Right_Shoulder_Upper.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_shoulder_roll_visual'>
-          <pose>0 0 0.0254 0 -0 2.25</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Right_Shoulder_Upper.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/joint0' type='revolute'>
-        <child>/r2/right_shoulder_roll</child>
-        <parent>/r2/waist_center</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.966946 -0.254715 -0.011608</xyz>
-          <limit>
-            <lower>-1.57</lower>
-            <upper>1.57</upper>
-            <effort>100</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>10</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/right_shoulder_pitch'>
-        <pose>-0.310064 -0.017271 1.26062 -1.44615 1.55909 0.389321</pose>
-        <inertial>
-          <pose>0.007798 0.037084 0.000284 0 -0 0</pose>
-          <mass>4.42706</mass>
-          <inertia>
-            <ixx>0.0113837</ixx>
-            <ixy>-2.17139e-05</ixy>
-            <ixz>-0.00151295</ixz>
-            <iyy>0.0251963</iyy>
-            <iyz>-5.23825e-05</iyz>
-            <izz>0.0270106</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_shoulder_pitch_collision'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Right_Shoulder_Lower.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_shoulder_pitch_visual'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Right_Shoulder_Lower.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/joint1' type='revolute'>
-        <child>/r2/right_shoulder_pitch</child>
-        <parent>/r2/right_shoulder_roll</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.261605 0.965174 0.001456</xyz>
-          <limit>
-            <lower>-1.66</lower>
-            <upper>0.175</upper>
-            <effort>100</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>10</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/right_upper_arm'>
-        <pose>-0.310064 -0.017271 1.26062 -3.01405 1.55909 0.389321</pose>
-        <inertial>
-          <pose>0.041402 -0.007417 0.1016 0 -0 0</pose>
-          <mass>4.85344</mass>
-          <inertia>
-            <ixx>0.0421401</ixx>
-            <ixy>-0.00137541</ixy>
-            <ixz>-0.00658439</ixz>
-            <iyy>0.0462371</iyy>
-            <iyz>-0.00339462</iyz>
-            <izz>0.0160074</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_upper_arm_collision'>
-          <pose>0 0 0.1016 0 -0 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Right_Upper_Arm.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_upper_arm_visual'>
-          <pose>0 0 0.1016 0 -0 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Right_Upper_Arm.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/joint2' type='revolute'>
-        <child>/r2/right_upper_arm</child>
-        <parent>/r2/right_shoulder_pitch</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.965868 -0.258774 -0.011614</xyz>
-          <limit>
-            <lower>0.785</lower>
-            <upper>4.89</upper>
-            <effort>100</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>10</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/right_elbow'>
-        <pose>-0.652578 -0.108954 1.2029 -1.44565 1.55909 0.389321</pose>
-        <inertial>
-          <pose>-0.026162 0.033782 0.015443 0 -0 0</pose>
-          <mass>2.97103</mass>
-          <inertia>
-            <ixx>0.0120275</ixx>
-            <ixy>-0.00118812</ixy>
-            <ixz>0.00164171</ixz>
-            <iyy>0.00883772</iyy>
-            <iyz>-0.00316051</iyz>
-            <izz>0.010535</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_elbow_collision'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Right_Elbow.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_elbow_visual'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Right_Elbow.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/joint3' type='revolute'>
-        <child>/r2/right_elbow</child>
-        <parent>/r2/right_upper_arm</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.261122 0.965305 0.001462</xyz>
-          <limit>
-            <lower>-2.79</lower>
-            <upper>-0.087</upper>
-            <effort>100</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/right_lower_arm'>
-        <pose>-0.653161 -0.109193 1.25664 -3.01125 1.55909 0.389321</pose>
-        <inertial>
-          <pose>0.000356 -0.001227 0.17653 0 -0 0</pose>
-          <mass>6.93996</mass>
-          <inertia>
-            <ixx>0.012525</ixx>
-            <ixy>0.000244647</ixy>
-            <ixz>0.000520899</ixz>
-            <iyy>0.0395064</iyy>
-            <iyz>0.000169146</iyz>
-            <izz>0.0403843</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_lower_arm_collision'>
-          <pose>0 0 0.1 0 -0 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Right_Forearm.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_lower_arm_visual'>
-          <pose>0 0 0.1 0 -0 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Right_Forearm.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/joint4' type='revolute'>
-        <child>/r2/right_lower_arm</child>
-        <parent>/r2/right_elbow</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.966589 -0.256069 -0.01161</xyz>
-          <limit>
-            <lower>-4.45</lower>
-            <upper>1.31</upper>
-            <effort>100</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/right_wrist_pitch'>
-        <pose>-0.998181 -0.200596 1.25249 -1.47835 1.55909 0.389321</pose>
-        <inertial>
-          <pose>0.000922 -0.004064 0 0 -0 0</pose>
-          <mass>0.116573</mass>
-          <inertia>
-            <ixx>1.69438e-05</ixx>
-            <ixy>5.4431e-08</ixy>
-            <ixz>-4.36033e-11</ixz>
-            <iyy>4.41886e-05</iyy>
-            <iyz>-1.75876e-06</iyz>
-            <izz>5.765e-05</izz>
-          </inertia>
-        </inertial>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/joint5' type='revolute'>
-        <child>/r2/right_wrist_pitch</child>
-        <parent>/r2/right_lower_arm</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.29254 0.956253 0.001081</xyz>
-          <limit>
-            <lower>-1.22</lower>
-            <upper>1.22</upper>
-            <effort>100</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/right_wrist_yaw'>
-        <pose>-1.00439 -0.202495 1.25256 3.13092 -0.009844 -2.8447</pose>
-        <inertial>
-          <pose>0.06374 -0.000207 0.021899 0 -0 0</pose>
-          <mass>1.33941</mass>
-          <inertia>
-            <ixx>0.00516672</ixx>
-            <ixy>-5.80194e-05</ixy>
-            <ixz>-0.000187327</ixz>
-            <iyy>0.00807358</iyy>
-            <iyz>0.000316215</iyz>
-            <izz>0.00654117</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_wrist_yaw_collision_/r2/right_palm'>
-          <pose>0 0 0 3.14 -0 1.5999</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Right_Palm.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-            </friction>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_wrist_yaw_visual_/r2/right_palm'>
-          <pose>0 0 0 3.14 -0 1.5999</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Right_Palm.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/joint6' type='revolute'>
-        <child>/r2/right_wrist_yaw</child>
-        <parent>/r2/right_wrist_pitch</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.012536 0.00733 -0.999895</xyz>
-          <limit>
-            <lower>-0.785</lower>
-            <upper>0.785</upper>
-            <effort>100</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/right_index_yaw'>
-        <pose>-1.09137 -0.257636 1.2694 3.1298 -0.008469 -2.72253</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.05</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/index/joint0' type='revolute'>
-        <child>/r2/right_index_yaw</child>
-        <parent>/r2/right_wrist_yaw</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.012536 0.00733 -0.999895</xyz>
-          <limit>
-            <lower>-0.3491</lower>
-            <upper>0.3491</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_index_proximal'>
-        <pose>-1.10018 -0.261563 1.26948 -1.58259 -0.008469 -2.72253</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.05</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_index_proximal_collision'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_index_proximal_visual'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/index/joint1' type='revolute'>
-        <child>/r2/right_index_proximal</child>
-        <parent>/r2/right_index_yaw</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.406785 -0.913448 -0.011797</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.57</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_index_medial'>
-        <pose>-1.14079 -0.279649 1.26986 -1.58259 -0.008469 -2.72253</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.05</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_index_medial_collision'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Mid.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_index_medial_visual'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Mid.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/index/joint2' type='revolute'>
-        <child>/r2/right_index_medial</child>
-        <parent>/r2/right_index_proximal</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.406785 -0.913448 -0.011797</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.57</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_index_distal'>
-        <pose>-1.16863 -0.292051 1.27012 -1.58259 -0.008469 -2.72253</pose>
-        <inertial>
-          <pose>0.012319 0 0 0 -0 0</pose>
-          <mass>0.1</mass>
-          <inertia>
-            <ixx>0.002</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.00201518</iyy>
-            <iyz>0</iyz>
-            <izz>0.00201518</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_index_distal_collision'>
-          <pose>0 0 0 0 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Dist.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_index_distal_visual'>
-          <pose>0 0 0 0 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Dist.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/index/joint3' type='revolute'>
-        <child>/r2/right_index_distal</child>
-        <parent>/r2/right_index_medial</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.406785 -0.913448 -0.011797</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.57</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_middle_yaw'>
-        <pose>-1.10525 -0.236187 1.26973 3.13092 -0.009844 -2.8447</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.001</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/middle/joint0' type='revolute'>
-        <child>/r2/right_middle_yaw</child>
-        <parent>/r2/right_wrist_yaw</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.012536 0.00733 -0.999895</xyz>
-          <limit>
-            <lower>-0.3491</lower>
-            <upper>0.3491</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_middle_proximal'>
-        <pose>-1.11448 -0.239011 1.26983 -1.58147 -0.009844 -2.8447</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.05</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_middle_proximal_collision'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>0.9 0.9 0.9</scale>
-              <uri>model://robonaut/meshes/Finger_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_middle_proximal_visual'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/middle/joint1' type='revolute'>
-        <child>/r2/right_middle_proximal</child>
-        <parent>/r2/right_middle_yaw</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.292433 -0.956226 -0.010677</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.57</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_middle_medial'>
-        <pose>-1.15698 -0.252014 1.27026 -1.58147 -0.009844 -2.8447</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.05</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_middle_medial_collision'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>0.9 0.9 0.9</scale>
-              <uri>model://robonaut/meshes/Finger_Mid.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_middle_medial_visual'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Mid.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/middle/joint2' type='revolute'>
-        <child>/r2/right_middle_medial</child>
-        <parent>/r2/right_middle_proximal</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.292433 -0.956226 -0.010677</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.57</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_middle_distal'>
-        <pose>-1.18612 -0.260931 1.27056 -1.58147 -0.009844 -2.8447</pose>
-        <inertial>
-          <pose>0.012319 0 0 0 -0 0</pose>
-          <mass>0.1</mass>
-          <inertia>
-            <ixx>0.002</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.00201518</iyy>
-            <iyz>0</iyz>
-            <izz>0.00201518</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_middle_distal_collision'>
-          <pose>0 0 0 0 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>0.9 0.9 0.9</scale>
-              <uri>model://robonaut/meshes/Finger_Dist.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_middle_distal_visual'>
-          <pose>0 0 0 0 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Dist.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/middle/joint3' type='revolute'>
-        <child>/r2/right_middle_distal</child>
-        <parent>/r2/right_middle_medial</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.292433 -0.956226 -0.010677</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.57</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_little_proximal'>
-        <pose>-1.10661 -0.191612 1.26001 -1.61453 0.075715 -3.02</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.05</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_little_proximal_collision'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>0.9 0.9 0.9</scale>
-              <uri>model://robonaut/meshes/Finger_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_little_proximal_visual'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/little/joint0' type='revolute'>
-        <child>/r2/right_little_proximal</child>
-        <parent>/r2/right_wrist_yaw</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.124457 -0.991267 -0.043598</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>2.9671</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_little_medial'>
-        <pose>-1.15061 -0.196988 1.25665 -1.61453 0.075715 -3.02</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.05</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_little_medial_collision'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>0.9 0.9 0.9</scale>
-              <uri>model://robonaut/meshes/Finger_Mid.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_little_medial_visual'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Mid.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/little/joint1' type='revolute'>
-        <child>/r2/right_little_medial</child>
-        <parent>/r2/right_little_proximal</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.124457 -0.991267 -0.043598</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>2.9671</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_little_distal'>
-        <pose>-1.18078 -0.200675 1.25434 -1.61453 0.075715 -3.02</pose>
-        <inertial>
-          <pose>0.012319 0 0 0 -0 0</pose>
-          <mass>0.1</mass>
-          <inertia>
-            <ixx>0.002</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.00201518</iyy>
-            <iyz>0</iyz>
-            <izz>0.00201518</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_little_distal_collision'>
-          <pose>0 0 0 0 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>0.9 0.9 0.9</scale>
-              <uri>model://robonaut/meshes/Finger_Dist.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_little_distal_visual'>
-          <pose>0 0 0 0 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Dist.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/little/joint2' type='revolute'>
-        <child>/r2/right_little_distal</child>
-        <parent>/r2/right_little_medial</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.124457 -0.991267 -0.043598</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>2.9671</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_ring_proximal'>
-        <pose>-1.11373 -0.215386 1.26615 -1.58019 -0.011072 -2.96687</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.05</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_ring_proximal_collision'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>0.9 0.9 0.9</scale>
-              <uri>model://robonaut/meshes/Finger_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_ring_proximal_visual'>
-          <pose>0 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/ring/joint0' type='revolute'>
-        <child>/r2/right_ring_proximal</child>
-        <parent>/r2/right_wrist_yaw</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.173722 -0.98475 -0.009397</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>2.9671</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_ring_medial'>
-        <pose>-1.1575 -0.223112 1.26665 -1.58019 -0.011072 -2.96687</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.05</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_ring_medial_collision'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>0.9 0.9 0.9</scale>
-              <uri>model://robonaut/meshes/Finger_Mid.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_ring_medial_visual'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Mid.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/ring/joint1' type='revolute'>
-        <child>/r2/right_ring_medial</child>
-        <parent>/r2/right_ring_proximal</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.173722 -0.98475 -0.009397</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>2.9671</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_ring_distal'>
-        <pose>-1.18751 -0.22841 1.26698 -1.58019 -0.011072 -2.96687</pose>
-        <inertial>
-          <pose>0.012319 0 0 0 -0 0</pose>
-          <mass>0.1</mass>
-          <inertia>
-            <ixx>0.002</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.00201518</iyy>
-            <iyz>0</iyz>
-            <izz>0.00201518</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_ring_distal_collision'>
-          <pose>0 0 0 0 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>0.9 0.9 0.9</scale>
-              <uri>model://robonaut/meshes/Finger_Dist.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_ring_distal_visual'>
-          <pose>0 0 0 0 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Finger_Dist.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/ring/joint2' type='revolute'>
-        <child>/r2/right_ring_distal</child>
-        <parent>/r2/right_ring_medial</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.173722 -0.98475 -0.009397</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>2.9671</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_thumb_base'>
-        <pose>-1.02713 -0.241254 1.24621 -1.58324 -0.166754 -1.53364</pose>
-        <inertial>
-          <pose>0.005969 0 0 0 -0 0</pose>
-          <mass>0.1</mass>
-          <inertia>
-            <ixx>0.002</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.00200356</iyy>
-            <iyz>-5.16988e-26</iyz>
-            <izz>0.00200356</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_thumb_base_collision_/r2/right_thumb_proximal'>
-          <pose>0.001938 0 0 -3.1408 0 0</pose>
-          <geometry>
-            <mesh>
-              <scale>0.9 0.9 0.9</scale>
-              <uri>model://robonaut/meshes/Left_Thumb_Carp.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_thumb_base_visual_/r2/right_thumb_proximal'>
-          <pose>0.001938 0 0 -3.1408 0 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Left_Thumb_Carp.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/thumb/joint0' type='revolute'>
-        <child>/r2/right_thumb_base</child>
-        <parent>/r2/right_wrist_yaw</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.999309 0.035079 -0.012272</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.2217</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_thumb_medial_prime'>
-        <pose>-1.02669 -0.253018 1.24819 3.12915 -0.166754 -1.53364</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.05</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_thumb_medial_prime_collision'>
-          <pose>-0 0 0 -1.57 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>0.9 0.9 0.9</scale>
-              <uri>model://robonaut/meshes/Right_Thumb_MtCar.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_thumb_medial_prime_visual'>
-          <pose>-0 0 0 -1.57 -1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Right_Thumb_MtCar.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/thumb/joint1' type='revolute'>
-        <child>/r2/right_thumb_medial_prime</child>
-        <parent>/r2/right_thumb_base</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.00627 -0.166318 -0.986052</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.3963</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_thumb_medial'>
-        <pose>-1.02365 -0.282816 1.25577 -2.4559 -0.166754 -1.53364</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.05</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_thumb_medial_collision'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Thumb_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_thumb_medial_visual'>
-          <pose>0 0 0 3.14 0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Thumb_Proximal.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/thumb/joint2' type='revolute'>
-        <child>/r2/right_thumb_medial</child>
-        <parent>/r2/right_thumb_medial_prime</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.637541 -0.104858 -0.763247</xyz>
-          <limit>
-            <lower>0</lower>
-            <upper>1.2217</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/right_thumb_distal'>
-        <pose>-1.0222 -0.321613 1.26231 -2.4559 -0.166754 -1.53364</pose>
-        <inertial>
-          <pose>0.01651 0 0 0 -0 0</pose>
-          <mass>0.1</mass>
-          <inertia>
-            <ixx>0.002</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.00202726</iyy>
-            <iyz>0</iyz>
-            <izz>0.00202726</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/right_thumb_distal_collision'>
-          <pose>0 0 0 -0.001593 0.001593 3.14159</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Thumb_Dist.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/right_thumb_distal_visual'>
-          <pose>0 0 0 -0.001593 0.001593 3.14159</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Thumb_Dist.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/right_arm/hand/thumb/joint3' type='revolute'>
-        <child>/r2/right_thumb_distal</child>
-        <parent>/r2/right_thumb_medial</parent>
-        <axis>
-          <xyz expressed_in='__model__'>0.637541 -0.104858 -0.763247</xyz>
-          <limit>
-            <lower>-0.5236</lower>
-            <upper>1.57</upper>
-            <effort>1e+07</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>0.1</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-      </joint>
-      <link name='/r2/neck_base'>
-        <pose>-0.000348 -0.087337 1.33408 1.5708 0.001593 -1.57478</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.1</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/neck_base_collision'>
-          <pose>0 0 0 -1.57 1.57 -0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Neck_Lower.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/neck_base_visual'>
-          <pose>0 0 0 -1.57 1.57 -0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Neck_Lower.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/neck/joint0' type='revolute'>
-        <child>/r2/neck_base</child>
-        <parent>/r2/waist_center</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.999992 0.003982 -0</xyz>
-          <limit>
-            <lower>-0.7</lower>
-            <upper>0.175</upper>
-            <effort>10000</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>10</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/neck_lower_pitch'>
-        <pose>-4.4e-05 -0.011138 1.33421 1e-06 0.001593 -1.57478</pose>
-        <inertial>
-          <pose>0 0 0 0 -0 0</pose>
-          <mass>0.1</mass>
-          <inertia>
-            <ixx>0.001</ixx>
-            <ixy>0</ixy>
-            <ixz>0</ixz>
-            <iyy>0.001</iyy>
-            <iyz>0</iyz>
-            <izz>0.001</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/neck_lower_pitch_collision'>
-          <pose>0.075 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Neck_Upper.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/neck_lower_pitch_visual'>
-          <pose>0.075 0 0 0 -0 1.57</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Neck_Upper.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/neck/joint1' type='revolute'>
-        <child>/r2/neck_lower_pitch</child>
-        <parent>/r2/neck_base</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-7e-06 -0.001593 0.999999</xyz>
-          <limit>
-            <lower>-1.22</lower>
-            <upper>1.22</upper>
-            <effort>10000</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>10</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <link name='/r2/neck_roll'>
-        <pose>-0.000248 -0.062221 1.51189 1.5708 0.001593 -1.57478</pose>
-        <inertial>
-          <pose>0.081499 0.101613 -0.011025 0 -0 0</pose>
-          <mass>1.13</mass>
-          <inertia>
-            <ixx>0.0270085</ixx>
-            <ixy>-0.00227738</ixy>
-            <ixz>0.000477847</ixz>
-            <iyy>0.0262663</iyy>
-            <iyz>0.000477211</iyz>
-            <izz>0.0277254</izz>
-          </inertia>
-        </inertial>
-        <collision name='/r2/neck_roll_collision'>
-          <pose>-0 0.07 0 0 1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Head.dae</uri>
-            </mesh>
-          </geometry>
-          <surface>
-            <contact>
-              <ode/>
-            </contact>
-            <friction>
-              <ode/>
-              <torsional>
-                <ode/>
-              </torsional>
-            </friction>
-            <bounce/>
-          </surface>
-          <max_contacts>10</max_contacts>
-        </collision>
-        <visual name='/r2/neck_roll_visual'>
-          <pose>-0 0.07 0 0 1.57 0</pose>
-          <geometry>
-            <mesh>
-              <scale>1 1 1</scale>
-              <uri>model://robonaut/meshes/Head.dae</uri>
-            </mesh>
-          </geometry>
-        </visual>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <sensor name='asus/ir' type='depth'>
-          <update_rate>1</update_rate>
-          <camera name='__default__'>
-            <image>
-              <format>L8</format>
-              <width>640</width>
-              <height>480</height>
-            </image>
-            <horizontal_fov>0.9948</horizontal_fov>
-            <clip>
-              <near>0.01</near>
-              <far>5</far>
-            </clip>
-          </camera>
-          <pose>0.12 0.14 -0.015 1.5708 -0 0</pose>
-        </sensor>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <sensor name='asus/rgb' type='depth'>
-          <update_rate>1</update_rate>
-          <camera name='__default__'>
-            <image>
-              <format>R8G8B8</format>
-              <width>640</width>
-              <height>480</height>
-            </image>
-            <horizontal_fov>0.9948</horizontal_fov>
-            <clip>
-              <near>0.01</near>
-              <far>5</far>
-            </clip>
-          </camera>
-          <pose>0.12 0.14 -0.045 -1.57239 -0 0</pose>
-        </sensor>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <sensor name='/r2/neck/head/camera0' type='camera'>
-          <update_rate>10</update_rate>
-          <camera name='__default__'>
-            <image>
-              <width>1600</width>
-              <height>1200</height>
-              <format>R8G8B8</format>
-            </image>
-            <horizontal_fov>1.5707</horizontal_fov>
-            <clip>
-              <near>0.1</near>
-              <far>50</far>
-            </clip>
-          </camera>
-          <pose>0.084487 0.107466 -0.048892 -1.57159 0.002389 -2e-06</pose>
-        </sensor>
-        <gravity>1</gravity>
-        <velocity_decay>
-          <linear>0</linear>
-          <angular>0</angular>
-        </velocity_decay>
-        <self_collide>0</self_collide>
-        <sensor name='/r2/neck/head/camera1' type='camera'>
-          <update_rate>10</update_rate>
-          <camera name='__default__'>
-            <image>
-              <width>1600</width>
-              <height>1200</height>
-              <format>R8G8B8</format>
-            </image>
-            <horizontal_fov>1.5707</horizontal_fov>
-            <clip>
-              <near>0.1</near>
-              <far>50</far>
-            </clip>
-          </camera>
-          <pose>0.084643 0.107544 0.048848 -1.57159 0.002389 -2e-06</pose>
-        </sensor>
-        <enable_wind>0</enable_wind>
-        <kinematic>0</kinematic>
-      </link>
-      <joint name='/r2/neck/joint2' type='revolute'>
-        <child>/r2/neck_roll</child>
-        <parent>/r2/neck_lower_pitch</parent>
-        <axis>
-          <xyz expressed_in='__model__'>-0.999992 0.003982 -0</xyz>
-          <limit>
-            <lower>-0.7</lower>
-            <upper>0.175</upper>
-            <effort>10000</effort>
-            <velocity>1000</velocity>
-          </limit>
-          <dynamics>
-            <damping>10</damping>
-            <spring_reference>0</spring_reference>
-            <spring_stiffness>0</spring_stiffness>
-          </dynamics>
-        </axis>
-        <physics>
-          <ode>
-            <limit>
-              <cfm>0</cfm>
-              <erp>0.2</erp>
-            </limit>
-          </ode>
-        </physics>
-      </joint>
-      <static>0</static>
-      <pose>-1.02905 4.91656 0 0 -0 0</pose>
-    </model>
     <state world_name='default'>
-      <sim_time>147 168000000</sim_time>
-      <real_time>170 549116752</real_time>
-      <wall_time>1611741532 553760096</wall_time>
-      <iterations>130396</iterations>
+      <sim_time>418 280000000</sim_time>
+      <real_time>291 225721583</real_time>
+      <wall_time>1612542940 91590132</wall_time>
+      <iterations>271112</iterations>
       <model name='ground_plane'>
         <pose>0 0 0 0 -0 0</pose>
         <scale>1 1 1</scale>
@@ -6122,508 +1533,384 @@
           <wrench>0 0 0 0 -0 0</wrench>
         </link>
       </model>
-      <model name='r2_clone'>
-        <pose>-1.05601 5.35394 0.050797 -0.000794 -4e-06 1.50734</pose>
-        <scale>1 1 1</scale>
-        <link name='/r2/left_elbow'>
-          <pose>-1.0442 5.66508 0.953206 1.54204 0.284121 -2.67885</pose>
-          <velocity>0.002518 -0.001841 6.5e-05 0.013873 0.010412 -0.014978</velocity>
-          <acceleration>0.965086 -2.0572 -0.405748 1.02772 1.48255 2.09316</acceleration>
-          <wrench>2.8673 -6.112 -1.20549 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_index_distal'>
-          <pose>-1.01801 5.81682 0.467908 2.80615 1.22669 0.617196</pose>
-          <velocity>-8.1e-05 0.002021 -0.000848 0.003964 -0.000495 -0.006516</velocity>
-          <acceleration>-0.489876 1.22038 0.75438 -0.690271 0.712688 -0.636115</acceleration>
-          <wrench>-0.00098 0.002441 0.001509 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_index_medial'>
-          <pose>-1.02468 5.80963 0.496769 3.00013 1.2432 0.822575</pose>
-          <velocity>-0.000151 0.001957 -0.00086 0.003785 -0.000757 -0.006629</velocity>
-          <acceleration>-0.475932 1.27527 0.837924 -0.724264 0.681499 -0.662522</acceleration>
-          <wrench>-0.000476 0.001275 0.000838 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_index_proximal'>
-          <pose>-1.0289 5.79545 0.538684 -2.8486 1.23159 1.28149</pose>
-          <velocity>-0.000321 0.001854 -0.00093 0.003143 -0.001697 -0.007006</velocity>
-          <acceleration>-0.475519 1.30568 0.791087 -1.06647 0.167532 -0.860306</acceleration>
-          <wrench>-0.000476 0.001306 0.000791 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_index_yaw'>
-          <pose>-1.02556 5.79017 0.546039 2.62725 0.866472 2.13605</pose>
-          <velocity>-0.000457 0.001841 -0.00091 -0.003091 -0.01083 -0.010713</velocity>
-          <acceleration>-0.51672 1.29633 0.716473 1.60864 1.14254 -2.99761</acceleration>
-          <wrench>-0.000517 0.001296 0.000716 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_little_distal'>
-          <pose>-1.04369 5.76234 0.440844 2.84294 1.2066 0.588834</pose>
-          <velocity>-0.000567 0.001072 -0.000659 -0.005413 0.00313 0.001364</velocity>
-          <acceleration>-0.531953 0.859542 0.759174 -2.47242 1.32609 1.29</acceleration>
-          <wrench>-0.001064 0.001719 0.001518 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_little_medial'>
-          <pose>-1.05112 5.75499 0.469475 3.02205 1.22081 0.779927</pose>
-          <velocity>-0.000475 0.001223 -0.000577 -0.005586 0.00291 0.001259</velocity>
-          <acceleration>-0.474903 0.957124 0.871058 -2.52784 1.31019 1.29358</acceleration>
-          <wrench>-0.000475 0.000957 0.000871 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_little_proximal'>
-          <pose>-1.05716 5.74058 0.511088 -2.89031 1.21165 1.17472</pose>
-          <velocity>-0.000376 0.001478 -0.000492 -0.006246 0.002066 0.000875</velocity>
-          <acceleration>-0.423553 1.05593 0.850374 -2.88871 0.804699 1.05125</acceleration>
-          <wrench>-0.000424 0.001056 0.00085 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_lower_arm'>
-          <pose>-1.09061 5.64193 0.93806 2.89505 0.144994 2.64638</pose>
-          <velocity>0.001946 -0.000936 0.000284 0.009366 0.008517 0.002035</velocity>
-          <acceleration>-0.055817 -0.112301 -0.337408 1.85401 1.49455 -0.250712</acceleration>
-          <wrench>-0.387365 -0.779364 -2.3416 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_middle_distal'>
-          <pose>-1.03982 5.79957 0.449026 2.66827 1.31718 0.559645</pose>
-          <velocity>-0.000266 0.001478 -0.000957 -0.001363 0.001832 -0.004491</velocity>
-          <acceleration>-0.444607 1.08788 0.759688 -1.03678 0.994943 -1.54935</acceleration>
-          <wrench>-0.000889 0.002176 0.001519 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_middle_medial'>
-          <pose>-1.04449 5.79442 0.478702 2.93562 1.34062 0.834898</pose>
-          <velocity>-0.000245 0.001545 -0.000922 -0.001546 0.001523 -0.004578</velocity>
-          <acceleration>-0.422075 1.16018 0.843677 -1.07435 0.966978 -1.58384</acceleration>
-          <wrench>-0.000422 0.00116 0.000844 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_middle_proximal'>
-          <pose>-1.04575 5.78373 0.521828 -2.74516 1.32627 1.45359</pose>
-          <velocity>-0.000277 0.001644 -0.000916 -0.002161 0.000455 -0.004856</velocity>
-          <acceleration>-0.415857 1.20358 0.795948 -1.35181 0.458844 -1.69513</acceleration>
-          <wrench>-0.000416 0.001204 0.000796 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_middle_yaw'>
-          <pose>-1.04179 5.77941 0.529504 2.76442 0.919316 2.31191</pose>
-          <velocity>-0.000378 0.001673 -0.00088 -0.007667 -0.00907 -0.00737</velocity>
-          <acceleration>-0.45761 1.19654 0.719711 1.70943 1.11939 -3.13747</acceleration>
-          <wrench>-0.000458 0.001197 0.00072 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_ring_distal'>
-          <pose>-1.037 5.79077 0.446745 2.86843 1.14646 0.605857</pose>
-          <velocity>-0.0005 0.001115 -0.000986 -0.005728 0.002666 0.002016</velocity>
-          <acceleration>-0.509832 0.8908 0.591847 -2.59237 1.09482 1.6936</acceleration>
-          <wrench>-0.00102 0.001782 0.001184 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_ring_medial'>
-          <pose>-1.0456 5.78218 0.47469 3.03147 1.16051 0.784117</pose>
-          <velocity>-0.000415 0.001263 -0.000894 -0.005898 0.002451 0.001894</velocity>
-          <acceleration>-0.455789 0.983896 0.706377 -2.64687 1.07758 1.70111</acceleration>
-          <wrench>-0.000456 0.000984 0.000706 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_ring_proximal'>
-          <pose>-1.05262 5.76541 0.515258 -2.89401 1.14952 1.17433</pose>
-          <velocity>-0.000324 0.001518 -0.00079 -0.006538 0.001637 0.00145</velocity>
-          <acceleration>-0.405704 1.08035 0.695201 -2.99982 0.587806 1.4165</acceleration>
-          <wrench>-0.000406 0.00108 0.000695 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_shoulder_pitch'>
-          <pose>-1.03619 5.65958 1.31364 1.70934 0.092828 1.31101</pose>
-          <velocity>0.002677 -0.008357 -0.000171 0.019142 0.001458 -0.003638</velocity>
-          <acceleration>2.16559 -4.10135 -0.783709 -2.21459 0.451975 -1.16129</acceleration>
-          <wrench>9.58721 -18.1569 -3.46953 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_shoulder_roll'>
-          <pose>-1.12149 5.35468 1.31509 1.57544 -0.137941 2.86818</pose>
-          <velocity>0.002264 -0.008271 -0.002948 0.011561 0.003321 -0.00227</velocity>
-          <acceleration>2.08773 -4.04344 -3.63525 0.316835 -0.407403 -2.53052</acceleration>
-          <wrench>12.8789 -24.9434 -22.4254 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_thumb_base'>
-          <pose>-0.991722 5.73855 0.57955 0.54363 0.444406 -0.005147</pose>
-          <velocity>-0.000855 0.002174 -7.8e-05 -0.012889 -0.007468 -0.002426</velocity>
-          <acceleration>-0.701516 1.38603 0.912942 2.59528 1.2432 1.81792</acceleration>
-          <wrench>-0.035777 0.070687 0.04656 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_thumb_distal'>
-          <pose>-0.975474 5.76014 0.511166 0.513929 1.27909 2.55428</pose>
-          <velocity>-0.000908 0.001733 -0.000195 -0.003864 -0.004873 0.001872</velocity>
-          <acceleration>-0.771722 1.12761 1.03824 0.506975 -1.43959 -1.71181</acceleration>
-          <wrench>-0.001543 0.002255 0.002076 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_thumb_medial'>
-          <pose>-0.969379 5.75216 0.549231 0.194542 1.31268 2.2227</pose>
-          <velocity>-0.001046 0.001907 -0.000116 -0.004256 -0.004064 0.002105</velocity>
-          <acceleration>-0.83593 1.30967 1.15955 -2.93386 -1.16544 1.60916</acceleration>
-          <wrench>-0.000836 0.00131 0.00116 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_thumb_medial_prime'>
-          <pose>-0.980944 5.7385 0.574418 -0.343305 1.05188 0.920929</pose>
-          <velocity>-0.000819 0.002082 6.4e-05 -0.009249 0.006248 0.005069</velocity>
-          <acceleration>-0.713494 1.38656 1.19155 -1.7629 0.174156 -0.365914</acceleration>
-          <wrench>-0.000713 0.001387 0.001192 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_upper_arm'>
-          <pose>-1.03619 5.65958 1.31364 3.11761 -0.164217 -2.6662</pose>
-          <velocity>0.002691 -0.00833 -0.000107 0.018669 0.0011 -0.016023</velocity>
-          <acceleration>1.27383 -3.28808 -1.12035 -0.280055 1.22254 0.846712</acceleration>
-          <wrench>6.18244 -15.9585 -5.43754 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_wrist_pitch'>
-          <pose>-1.00518 5.69482 0.595433 1.24922 -0.577475 2.86643</pose>
-          <velocity>-0.001131 0.002403 0.000527 -0.001421 -0.009588 -0.016084</velocity>
-          <acceleration>-0.950118 1.56096 1.67915 2.35556 0.993117 -1.0627</acceleration>
-          <wrench>-0.110758 0.181965 0.195743 0 -0 0</wrench>
-        </link>
-        <link name='/r2/left_wrist_yaw'>
-          <pose>-1.00767 5.69752 0.590597 2.43441 0.735378 1.86881</pose>
-          <velocity>-0.001064 0.002372 0.000362 -0.013274 -0.006919 -0.00325</velocity>
-          <acceleration>-0.579326 1.12206 1.17196 2.93716 0.892249 -0.00612</acceleration>
-          <wrench>-1.37811 2.66918 2.78788 0 -0 0</wrench>
-        </link>
-        <link name='/r2/neck_base'>
-          <pose>-0.969741 5.35295 1.38495 1.57087 0.700829 -0.011361</pose>
-          <velocity>0.002375 -0.009028 -0.00397 0.008583 0.03659 -0.002201</velocity>
-          <acceleration>1.25492 -3.86546 -7.16527 0.256132 -0.67857 1.506</acceleration>
-          <wrench>0.125492 -0.386546 -0.716527 0 -0 0</wrench>
-        </link>
-        <link name='/r2/neck_lower_pitch'>
-          <pose>-1.02797 5.35361 1.43409 -0.051938 0.69928 -0.092047</pose>
-          <velocity>0.004433 -0.00917 -0.000871 0.019699 0.025014 0.019363</velocity>
-          <acceleration>4.23076 -4.49471 -3.22736 1.01515 1.01915 1.42932</acceleration>
-          <wrench>0.423076 -0.449471 -0.322736 0 -0 0</wrench>
-        </link>
-        <link name='/r2/neck_roll'>
-          <pose>-0.874628 5.34873 1.53724 1.34083 1.39553 -0.285152</pose>
-          <velocity>0.007701 -0.007682 -0.00254 0.013083 -0.005607 0.024838</velocity>
-          <acceleration>9.73041 -3.47838 -5.93078 -1.61678 0.22221 -2.02618</acceleration>
-          <wrench>10.9954 -3.93056 -6.70178 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_elbow'>
-          <pose>-1.04638 5.03245 0.952363 -1.5856 -0.257616 0.846594</pose>
-          <velocity>0.001831 -0.000794 -0.002565 0.007058 0.012011 -0.001736</velocity>
-          <acceleration>1.01349 -0.452573 -3.7419 -1.99727 -1.55529 -2.60761</acceleration>
-          <wrench>3.01111 -1.34461 -11.1173 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_index_distal'>
-          <pose>-0.978894 5.05801 0.405085 1.64271 1.57072 2.41755</pose>
-          <velocity>-0.001068 0.000292 -0.001085 0.000504 -0.001102 0.003336</velocity>
-          <acceleration>-0.53616 0.145555 -2.24744 0.361451 -0.833307 -0.750656</acceleration>
-          <wrench>-0.053616 0.014556 -0.224744 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_index_medial'>
-          <pose>-0.978894 5.05801 0.435563 1.64851 1.57072 2.42335</pose>
-          <velocity>-0.001137 0.000312 -0.001037 -0.000685 -0.002269 0.003342</velocity>
-          <acceleration>-0.597756 0.153941 -2.1866 2.7413 -1.55417 2.39602</acceleration>
-          <wrench>-0.029888 0.007697 -0.10933 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_index_proximal'>
-          <pose>-0.978892 5.05802 0.48002 1.65275 1.57073 2.42758</pose>
-          <velocity>-0.001318 0.000425 -0.001079 -0.002507 -0.004055 0.003337</velocity>
-          <acceleration>-0.746663 0.254181 -2.24037 0.886527 0.264107 2.39658</acceleration>
-          <wrench>-0.037333 0.012709 -0.112019 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_index_yaw'>
-          <pose>-0.979606 5.05874 0.489612 3.14154 1.46477 -0.796006</pose>
-          <velocity>-0.001441 0.000532 -0.001176 -0.011281 -0.012653 0.003326</velocity>
-          <acceleration>-0.810541 0.312835 -2.35169 0.153927 -0.926555 -0.744043</acceleration>
-          <wrench>-0.040527 0.015642 -0.117585 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_little_distal'>
-          <pose>-1.0454 5.00895 0.421189 3.14158 1.37648 -2.35208</pose>
-          <velocity>-0.000859 0.000305 -0.0018 0.002012 -0.003774 0.000606</velocity>
-          <acceleration>-0.510579 0.346165 -2.80517 -1.88394 -0.67519 0.9064</acceleration>
-          <wrench>-0.051058 0.034617 -0.280517 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_little_medial'>
-          <pose>-1.04125 5.01313 0.451098 3.14159 1.37648 -2.35207</pose>
-          <velocity>-0.001023 0.000293 -0.00173 0.000482 -0.005321 0.001044</velocity>
-          <acceleration>-0.635209 0.311134 -2.72642 -2.83818 0.312873 1.18071</acceleration>
-          <wrench>-0.03176 0.015557 -0.136321 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_little_proximal'>
-          <pose>-1.03521 5.01922 0.494715 -3.14158 1.37648 -2.35205</pose>
-          <velocity>-0.001373 0.000381 -0.001735 -0.001844 -0.007699 0.00169</velocity>
-          <acceleration>-0.867698 0.371636 -2.75355 -1.68613 0.790904 -1.38679</acceleration>
-          <wrench>-0.043385 0.018582 -0.137677 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_lower_arm'>
-          <pose>-1.08081 4.99353 0.938669 2.88381 -0.002852 2.36884</pose>
-          <velocity>0.001628 -0.000631 -0.002306 0.004994 0.011345 0.007558</velocity>
-          <acceleration>-0.072268 0.226127 -3.75647 1.66536 -0.269377 2.50696</acceleration>
-          <wrench>-0.50154 1.56931 -26.0697 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_middle_distal'>
-          <pose>-0.996063 5.04023 0.398576 3.09713 1.57076 -2.41122</pose>
-          <velocity>-0.000367 1.5e-05 0.000517 0.000222 -0.000307 0.003252</velocity>
-          <acceleration>-0.324669 0.07505 0.160323 0.303239 -0.538159 -0.772931</acceleration>
-          <wrench>-0.032467 0.007505 0.016032 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_middle_medial'>
-          <pose>-0.996064 5.04023 0.429051 3.13545 1.57076 -2.37289</pose>
-          <velocity>-0.000377 1.1e-05 0.00053 5e-05 -0.000469 0.003257</velocity>
-          <acceleration>-0.357299 0.072566 0.17831 -0.057365 -0.892054 -0.768588</acceleration>
-          <wrench>-0.017865 0.003628 0.008916 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_middle_proximal'>
-          <pose>-0.996063 5.04023 0.473498 -1.76628 1.57064 -0.991446</pose>
-          <velocity>-0.000411 1.9e-05 0.000519 -0.000167 -0.00068 0.003252</velocity>
-          <acceleration>-0.474935 0.154105 0.162156 1.31199 -0.515396 2.37442</acceleration>
-          <wrench>-0.023747 0.007705 0.008108 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_middle_yaw'>
-          <pose>-0.996781 5.04096 0.483075 3.1413 1.46477 -0.796249</pose>
-          <velocity>-0.000223 1.2e-05 0.0013 -0.011765 -0.012025 0.003244</velocity>
-          <acceleration>-0.455445 0.183313 1.2934 0.057225 -0.643667 -0.764494</acceleration>
-          <wrench>-0.000455 0.000183 0.001293 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_ring_distal'>
-          <pose>-1.02299 5.02065 0.407041 3.14126 1.42915 -2.38227</pose>
-          <velocity>-0.000719 0.000345 -0.001585 0.002642 -0.004007 0.001403</velocity>
-          <acceleration>-0.387665 0.3226 -2.68145 -1.45806 -0.496182 1.39457</acceleration>
-          <wrench>-0.038766 0.03226 -0.268145 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_ring_medial'>
-          <pose>-1.01987 5.0236 0.437212 3.14128 1.42915 -2.38225</pose>
-          <velocity>-0.000882 0.000308 -0.001518 0.001362 -0.005231 0.001664</velocity>
-          <acceleration>-0.518434 0.269382 -2.60492 -2.2441 0.286618 1.55743</acceleration>
-          <wrench>-0.025922 0.013469 -0.130246 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_ring_proximal'>
-          <pose>-1.01532 5.02793 0.481216 3.14131 1.42915 -2.38222</pose>
-          <velocity>-0.001204 0.000339 -0.001529 -0.000538 -0.007054 0.002032</velocity>
-          <acceleration>-0.743498 0.30463 -2.63663 -0.985401 1.05606 -1.20356</acceleration>
-          <wrench>-0.037175 0.015232 -0.131832 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_shoulder_pitch'>
-          <pose>-1.04205 5.04376 1.3114 -1.4275 0.108255 1.84535</pose>
-          <velocity>0.002214 -0.00841 -0.002512 0.021349 0.001069 -0.001822</velocity>
-          <acceleration>2.0327 -3.45549 -3.95403 -1.09325 -0.284008 -2.39782</acceleration>
-          <wrench>8.99887 -15.2977 -17.5047 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_shoulder_roll'>
-          <pose>-1.12149 5.35468 1.31509 1.58241 0.14253 0.251792</pose>
-          <velocity>0.002282 -0.008407 -0.002613 -0.000991 -0.004236 0.001463</velocity>
-          <acceleration>1.97419 -3.80836 -4.95838 0.137426 0.604639 0.573464</acceleration>
-          <wrench>12.1785 -23.4933 -30.5876 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_thumb_base'>
-          <pose>-0.996805 5.08305 0.553224 0.021791 0.30009 1.19857</pose>
-          <velocity>-0.002477 0.001033 -0.001794 -0.008306 -0.014128 0.006545</velocity>
-          <acceleration>-1.32438 0.609613 -2.80989 -1.04302 -1.20797 -2.1086</acceleration>
-          <wrench>-0.132438 0.060961 -0.280989 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_thumb_distal'>
-          <pose>-0.991798 5.09291 0.47953 -3.1415 1.56568 -1.07628</pose>
-          <velocity>-0.001568 0.000889 -0.00169 -0.006876 -0.004177 0.006272</velocity>
-          <acceleration>-0.791682 0.457929 -2.66941 -0.511518 -0.481566 -2.22203</acceleration>
-          <wrench>-0.079168 0.045793 -0.266942 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_thumb_medial'>
-          <pose>-0.990567 5.0938 0.518871 1.7028 1.53195 -2.51526</pose>
-          <velocity>-0.001955 0.001048 -0.001634 -0.003893 -0.009702 0.006304</velocity>
-          <acceleration>-1.02428 0.624958 -2.60885 0.485922 1.52968 -2.21316</acceleration>
-          <wrench>-0.051214 0.031248 -0.130443 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_thumb_medial_prime'>
-          <pose>-0.992658 5.09367 0.549697 1.00474 1.53197 -2.51519</pose>
-          <velocity>-0.002497 0.001025 -0.001712 0.00037 -0.017597 0.006349</velocity>
-          <acceleration>-1.32583 0.611984 -2.68042 -2.93307 0.534825 -2.19039</acceleration>
-          <wrench>-0.066291 0.030599 -0.134021 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_upper_arm'>
-          <pose>-1.04205 5.04376 1.3114 3.12943 0.181272 0.840199</pose>
-          <velocity>0.002235 -0.008407 -0.002453 0.020798 0.001184 -0.002086</velocity>
-          <acceleration>1.84307 -2.87032 -3.77289 -1.02983 0.423703 -3.11038</acceleration>
-          <wrench>8.94524 -13.9309 -18.3115 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_wrist_pitch'>
-          <pose>-1.01799 5.05938 0.593513 -1.86739 0.082669 2.34273</pose>
-          <velocity>-0.002847 0.001432 -0.001673 -0.000448 -0.023378 0.006412</velocity>
-          <acceleration>-1.6228 0.907641 -2.64419 2.51127 0.367089 0.773534</acceleration>
-          <wrench>-0.189175 0.105806 -0.308241 0 -0 0</wrench>
-        </link>
-        <link name='/r2/right_wrist_yaw'>
-          <pose>-1.01617 5.06023 0.587339 2.95325 1.46285 -0.985374</pose>
-          <velocity>-0.002914 0.001275 -0.001932 -0.00891 -0.015051 0.00366</velocity>
-          <acceleration>-1.0664 0.48367 -3.06835 0.905462 0.691546 1.99413</acceleration>
-          <wrench>-1.42835 0.647832 -4.10978 0 -0 0</wrench>
-        </link>
-        <link name='/r2/robot_world'>
-          <pose>-1.05601 5.35394 0.050797 -0.000794 -4e-06 1.50734</pose>
-          <velocity>-0.000481 -0.00059 -0.003528 0.006227 0.002208 -0.001125</velocity>
-          <acceleration>0.752568 -2.07849 -6.78318 2.69698 1.2391 -0.238855</acceleration>
-          <wrench>42.1513 -116.416 -379.926 0 -0 0</wrench>
-        </link>
-        <link name='/r2/waist_center'>
-          <pose>-1.05658 5.35397 0.770797 -3.14154 0.000797 -0.011405</pose>
-          <velocity>0.001113 -0.005064 -0.003526 0.006269 0.002187 -0.000938</velocity>
-          <acceleration>1.04131 -2.37705 -6.78211 2.60056 0.717915 0.240125</acceleration>
-          <wrench>20.9616 -47.85 -136.524 0 -0 0</wrench>
-        </link>
-      </model>
       <model name='unit_box'>
-        <pose>-1.16562 1.47277 0.499995 0 -1e-05 -0.00321</pose>
+        <pose>-1.17439 1.44806 0.499995 -1e-05 -0 0.006424</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>-1.16562 1.47277 0.499995 0 -1e-05 -0.00321</pose>
+          <pose>-1.17439 1.44806 0.499995 -1e-05 -0 0.006424</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.010636 -0.006191 -9.78231 0.01243 -0.021267 -2.1e-05</acceleration>
-          <wrench>-0.010636 -0.006191 -9.78231 0 -0 0</wrench>
+          <acceleration>0.00469 0.011087 -9.78157 -0.022171 0.009377 1e-06</acceleration>
+          <wrench>0.00469 0.011087 -9.78157 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone'>
+        <pose>-4.3626 -1.64811 0.499995 0 -1e-05 0.000193</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-4.3626 -1.64811 0.499995 0 -1e-05 0.000193</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0.010616 0.006191 -9.78231 -0.012424 -0.021228 1.9e-05</acceleration>
+          <wrench>-0.010616 0.006191 -9.78231 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_0'>
+        <pose>-4.24314 -2.64864 0.499995 -1e-05 -0 6.2e-05</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-4.24314 -2.64864 0.499995 -1e-05 -0 6.2e-05</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0.006705 0.013337 -9.77778 -0.026648 -0.013411 -5e-06</acceleration>
+          <wrench>-0.006705 0.013337 -9.77778 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_1'>
+        <pose>-4.26465 -3.64876 0.499995 1e-05 -0 -0.000161</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-4.26465 -3.64876 0.499995 1e-05 -0 -0.000161</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0.006276 -0.012841 -9.7786 0.025661 -0.012552 5e-06</acceleration>
+          <wrench>-0.006276 -0.012841 -9.7786 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_2'>
+        <pose>-5.38649 -3.69388 0.499995 1e-05 -0 0</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-5.38649 -3.69388 0.499995 1e-05 -0 0</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0.004709 -0.011055 -9.78158 0.022108 0.009414 -1e-06</acceleration>
+          <wrench>0.004709 -0.011055 -9.78158 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_3'>
+        <pose>-6.42361 -3.63876 0.499995 0 1e-05 0.000533</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-6.42361 -3.63876 0.499995 0 1e-05 0.000533</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0.010611 0.006192 -9.78231 -0.012423 0.021218 -1.8e-05</acceleration>
+          <wrench>0.010611 0.006192 -9.78231 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_4'>
+        <pose>-7.42547 -3.53033 0.499995 0 -1e-05 0.002284</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-7.42547 -3.53033 0.499995 0 -1e-05 0.002284</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0.01063 0.006191 -9.78231 -0.012428 -0.021255 2.1e-05</acceleration>
+          <wrench>-0.01063 0.006191 -9.78231 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_5'>
+        <pose>-3.1737 1.32705 0.499995 -1e-05 -0 0.00633</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-3.1737 1.32705 0.499995 -1e-05 -0 0.00633</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0.004581 0.011022 -9.78158 -0.022036 -0.00922 -4.5e-05</acceleration>
+          <wrench>-0.004581 0.011022 -9.78158 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_6'>
+        <pose>-4.17579 1.2882 0.499995 1e-05 -0 0.001701</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-4.17579 1.2882 0.499995 1e-05 -0 0.001701</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0.004711 -0.011064 -9.78157 0.022125 -0.009418 1e-06</acceleration>
+          <wrench>-0.004711 -0.011064 -9.78157 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_clone'>
+        <pose>-3.32293 -1.53757 0.5 0 -0 0.001688</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-3.32293 -1.53757 0.5 0 -0 0.001688</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0 -0 0 1e-06 -1e-06 0</acceleration>
+          <wrench>-0 -0 0 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_clone_0'>
+        <pose>-4.19149 2.29062 0.499995 0 -1e-05 0.000943</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-4.19149 2.29062 0.499995 0 -1e-05 0.000943</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0.010608 -0.006192 -9.78231 0.012422 -0.021213 -1.8e-05</acceleration>
+          <wrench>-0.010608 -0.006192 -9.78231 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_clone_1'>
+        <pose>-8.43346 -3.52384 0.499995 0 -1e-05 -0.000938</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-8.43346 -3.52384 0.499995 0 -1e-05 -0.000938</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0.010621 -0.006191 -9.78231 0.012425 -0.021238 -1.9e-05</acceleration>
+          <wrench>-0.010621 -0.006191 -9.78231 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_clone_10'>
+        <pose>-8.3811 1.47728 0.5 0 -0 -0.001058</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-8.3811 1.47728 0.5 0 -0 -0.001058</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>9.78195 -0.016543 9.7823 0.033125 0.714344 -6e-05</acceleration>
+          <wrench>9.78195 -0.016543 9.7823 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_clone_2'>
+        <pose>-6.35549 2.27017 0.5 0 -0 -0.003829</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-6.35549 2.27017 0.5 0 -0 -0.003829</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>4.89091 -0.018671 4.89096 -3.10427 -0.356983 3.14157</acceleration>
+          <wrench>4.89091 -0.018671 4.89096 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_clone_3'>
+        <pose>-7.3551 2.37784 0.5 0 0 -0.003825</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-7.3551 2.37784 0.5 0 0 -0.003825</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-9.78187 0.031217 9.7823 -0.062391 -0.714167 6.2e-05</acceleration>
+          <wrench>-9.78187 0.031217 9.7823 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_clone_4'>
+        <pose>-8.55474 2.47929 0.499995 0 -1e-05 -0.000718</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-8.55474 2.47929 0.499995 0 -1e-05 -0.000718</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0.01061 0.006192 -9.78231 -0.012423 -0.021216 1.8e-05</acceleration>
+          <wrench>-0.01061 0.006192 -9.78231 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_clone_5'>
+        <pose>-8.48234 -2.52377 0.499941 0 0 -0.0009</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-8.48234 -2.52377 0.499941 0 0 -0.0009</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0 -0 -9.8 0 -0 0</acceleration>
+          <wrench>-0 -0 -9.8 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_clone_6'>
+        <pose>-5.22675 2.18076 0.499995 0 1e-05 0.00589</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-5.22675 2.18076 0.499995 0 1e-05 0.00589</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0.010573 0.006193 -9.78232 -0.012415 0.021143 -1.2e-05</acceleration>
+          <wrench>0.010573 0.006193 -9.78232 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_clone_7'>
+        <pose>-8.57371 -1.52365 0.5 0 0 -0.000811</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-8.57371 -1.52365 0.5 0 0 -0.000811</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0.002533 -9.77818 9.77701 0.706796 -0.00506 5e-05</acceleration>
+          <wrench>-0.002533 -9.77818 9.77701 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_clone_8'>
+        <pose>-8.562 -0.523057 0.5 -0 -0 -0.0018</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-8.562 -0.523057 0.5 -0 -0 -0.0018</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>9.78196 -0.011421 9.78232 0.022796 0.714362 6.3e-05</acceleration>
+          <wrench>9.78196 -0.011421 9.78232 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_0_clone_clone_9'>
+        <pose>-8.36662 0.477259 0.5 -0 -0 -0.001058</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-8.36662 0.477259 0.5 -0 -0 -0.001058</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0.015057 -9.78111 9.78157 0.712656 -0.03011 -4.3e-05</acceleration>
+          <wrench>-0.015057 -9.78111 9.78157 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone'>
-        <pose>-0.165611 1.46657 0.499995 1e-05 0 -0.003192</pose>
+        <pose>-0.164448 1.46231 0.499995 -1e-05 -0 0.003311</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>-0.165611 1.46657 0.499995 1e-05 0 -0.003192</pose>
+          <pose>-0.164448 1.46231 0.499995 -1e-05 -0 0.003311</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>0.004713 -0.011072 -9.78157 0.02214 0.009422 -1e-06</acceleration>
-          <wrench>0.004713 -0.011072 -9.78157 0 -0 0</wrench>
+          <acceleration>0.004713 0.011072 -9.78157 -0.022141 0.009422 1e-06</acceleration>
+          <wrench>0.004713 0.011072 -9.78157 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_0'>
-        <pose>0.834437 1.41995 0.499995 -1e-05 -0 -0.002967</pose>
+        <pose>0.836914 1.41912 0.5 0 -0 0.000743</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>0.834437 1.41995 0.499995 -1e-05 -0 -0.002967</pose>
+          <pose>0.836914 1.41912 0.5 0 -0 0.000743</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.004713 0.011071 -9.78157 -0.022138 -0.009422 -1e-06</acceleration>
-          <wrench>-0.004713 0.011071 -9.78157 0 -0 0</wrench>
+          <acceleration>-0 -0 -0 1e-06 -1e-06 0</acceleration>
+          <wrench>-0 -0 -0 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_1'>
-        <pose>1.83574 1.38529 0.499995 1e-05 -0 -0.001343</pose>
+        <pose>1.83889 1.38351 0.499995 0 1e-05 0.000138</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>1.83574 1.38529 0.499995 1e-05 -0 -0.001343</pose>
+          <pose>1.83889 1.38351 0.499995 0 1e-05 0.000138</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.004707 -0.011048 -9.78158 0.022093 -0.00941 1e-06</acceleration>
-          <wrench>-0.004707 -0.011048 -9.78158 0 -0 0</wrench>
+          <acceleration>0.010614 0.006192 -9.78231 -0.012424 0.021223 -1.8e-05</acceleration>
+          <wrench>0.010614 0.006192 -9.78231 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_10'>
-        <pose>5.23777 2.53227 0.5 0 -0 0.007307</pose>
+        <pose>5.24223 2.5241 0.499995 0 -1e-05 0.006777</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>5.23777 2.53227 0.5 0 -0 0.007307</pose>
+          <pose>5.24223 2.5241 0.499995 0 -1e-05 0.006777</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>0.076297 -9.7803 9.78073 0.711039 0.152592 4.4e-05</acceleration>
-          <wrench>0.076297 -9.7803 9.78073 0 -0 0</wrench>
+          <acceleration>-0.010566 -0.006194 -9.78232 0.012414 -0.02113 -1.1e-05</acceleration>
+          <wrench>-0.010566 -0.006194 -9.78232 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_11'>
-        <pose>5.22385 1.53214 0.499908 7e-06 -0 0.007307</pose>
+        <pose>5.22201 1.52394 0.499995 0 1e-05 0.006778</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>5.22385 1.53214 0.499908 7e-06 -0 0.007307</pose>
+          <pose>5.22201 1.52394 0.499995 0 1e-05 0.006778</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0 0 -9.8 0 -0 0</acceleration>
-          <wrench>-0 0 -9.8 0 -0 0</wrench>
+          <acceleration>0.010658 -0.006191 -9.78231 0.012436 0.021312 2.5e-05</acceleration>
+          <wrench>0.010658 -0.006191 -9.78231 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_12'>
-        <pose>5.24345 0.532244 0.499995 0 -1e-05 0.007307</pose>
+        <pose>5.24227 0.523939 0.5 0 -0 0.007004</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>5.24345 0.532244 0.499995 0 -1e-05 0.007307</pose>
+          <pose>5.24227 0.523939 0.5 0 -0 0.007004</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.010562 -0.006194 -9.78232 0.012414 -0.021122 -1.1e-05</acceleration>
-          <wrench>-0.010562 -0.006194 -9.78232 0 -0 0</wrench>
+          <acceleration>9.78178 0.062353 9.78235 -0.124651 0.713991 -6.8e-05</acceleration>
+          <wrench>9.78178 0.062353 9.78235 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_13'>
-        <pose>5.28865 -0.467508 0.5 0 -0 0.007378</pose>
+        <pose>5.28859 -0.475823 0.5 0 -0 0.007122</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>5.28865 -0.467508 0.5 0 -0 0.007378</pose>
+          <pose>5.28859 -0.475823 0.5 0 -0 0.007122</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0 -0 -0 1e-06 -1e-06 0</acceleration>
-          <wrench>-0 -0 -0 0 -0 0</wrench>
+          <acceleration>9.78177 0.063398 9.78236 -0.126802 0.713984 -4.5e-05</acceleration>
+          <wrench>9.78177 0.063398 9.78236 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_14'>
-        <pose>5.21453 -2.46849 0.5 0 -0 0.006653</pose>
+        <pose>5.21376 -2.47652 0.499995 1e-05 -0 0.007311</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>5.21453 -2.46849 0.5 0 -0 0.006653</pose>
+          <pose>5.21376 -2.47652 0.499995 1e-05 -0 0.007311</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0 -0 -0 1e-06 -1e-06 0</acceleration>
-          <wrench>-0 -0 -0 0 -0 0</wrench>
+          <acceleration>-0.102679 -0.108693 -9.62013 0.217312 -0.207511 0.001154</acceleration>
+          <wrench>-0.102679 -0.108693 -9.62013 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_15'>
-        <pose>5.28279 -3.46806 0.5 0 -0 0.006655</pose>
+        <pose>5.28351 -3.47604 0.499995 -9e-06 -0 0.007329</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>5.28279 -3.46806 0.5 0 -0 0.006655</pose>
+          <pose>5.28351 -3.47604 0.499995 -9e-06 -0 0.007329</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>9.7818 0.058942 9.78235 -0.117829 0.714033 -6.7e-05</acceleration>
-          <wrench>9.7818 0.058942 9.78235 0 -0 0</wrench>
+          <acceleration>-0.087779 0.119811 -9.59927 -0.239536 -0.177629 -0.001122</acceleration>
+          <wrench>-0.087779 0.119811 -9.59927 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_15_clone'>
-        <pose>5.34844 -4.46768 0.499995 0 -1e-05 0.006671</pose>
+        <pose>5.35008 -4.4756 0.499995 1e-05 -0 0.007352</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>5.34844 -4.46768 0.499995 0 -1e-05 0.006671</pose>
+          <pose>5.35008 -4.4756 0.499995 1e-05 -0 0.007352</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.010567 -0.006194 -9.78232 0.012414 -0.021132 -1.1e-05</acceleration>
-          <wrench>-0.010567 -0.006194 -9.78232 0 -0 0</wrench>
+          <acceleration>-0.101054 -0.109265 -9.61917 0.218441 -0.204652 0.001364</acceleration>
+          <wrench>-0.101054 -0.109265 -9.61917 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_clone_16'>
+        <pose>3.96539 7.42324 0.5 0 0 -0.018487</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>3.96539 7.42324 0.5 0 0 -0.018487</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0 -0 0 1e-06 1e-06 0</acceleration>
+          <wrench>0 -0 0 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_17'>
-        <pose>1.79247 -2.80223 0.499995 0 -1e-05 0.024108</pose>
+        <pose>1.79247 -2.80224 0.499995 0 -1e-05 0.024104</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>1.79247 -2.80223 0.499995 0 -1e-05 0.024108</pose>
+          <pose>1.79247 -2.80224 0.499995 0 -1e-05 0.024104</pose>
           <velocity>0 0 0 0 -0 0</velocity>
           <acceleration>-0.010749 0.006163 -9.78234 -0.012407 -0.021491 3.8e-05</acceleration>
           <wrench>-0.010749 0.006163 -9.78234 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_18'>
-        <pose>1.87858 -3.80046 0.499995 -0 -1e-05 0.024075</pose>
+        <pose>1.87859 -3.80047 0.499995 0 -1e-05 0.024072</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>1.87858 -3.80046 0.499995 -0 -1e-05 0.024075</pose>
+          <pose>1.87859 -3.80047 0.499995 0 -1e-05 0.024072</pose>
           <velocity>0 0 0 0 -0 0</velocity>
           <acceleration>-0.010749 0.006163 -9.78234 -0.012407 -0.021491 3.8e-05</acceleration>
           <wrench>-0.010749 0.006163 -9.78234 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_18_clone'>
-        <pose>2.33664 -4.80546 0.499995 0 -1e-05 -0.007082</pose>
+        <pose>2.33664 -4.80546 0.499995 1e-05 -0 -0.007083</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>2.33664 -4.80546 0.499995 0 -1e-05 -0.007082</pose>
+          <pose>2.33664 -4.80546 0.499995 1e-05 -0 -0.007083</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.01891 0.015108 -9.76832 -0.030641 -0.03777 0.000201</acceleration>
-          <wrench>-0.01891 0.015108 -9.76832 0 -0 0</wrench>
+          <acceleration>-0.004697 -0.011015 -9.78159 0.022027 -0.009392 1e-06</acceleration>
+          <wrench>-0.004697 -0.011015 -9.78159 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_19'>
-        <pose>3.33755 -4.68844 0.499995 0 1e-05 -0.006964</pose>
+        <pose>3.33754 -4.68844 0.499995 1e-05 -0 -0.006964</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>3.33755 -4.68844 0.499995 0 1e-05 -0.006964</pose>
+          <pose>3.33754 -4.68844 0.499995 1e-05 -0 -0.006964</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>0.019208 -0.015557 -9.76782 0.031559 0.038365 0.000211</acceleration>
-          <wrench>0.019208 -0.015557 -9.76782 0 -0 0</wrench>
+          <acceleration>-0.004698 -0.011016 -9.78159 0.022029 -0.009392 1e-06</acceleration>
+          <wrench>-0.004698 -0.011016 -9.78159 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_2'>
-        <pose>5.22909 4.53402 0.5 0 -0 0.010296</pose>
+        <pose>5.22257 4.52446 0.5 0 -0 0.005913</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>5.22909 4.53402 0.5 0 -0 0.010296</pose>
+          <pose>5.22257 4.52446 0.5 0 -0 0.005913</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>9.78139 0.106963 9.78227 -0.213944 0.713212 5e-05</acceleration>
-          <wrench>9.78139 0.106963 9.78227 0 -0 0</wrench>
+          <acceleration>-0.063367 9.77782 9.78037 -0.706108 -0.126718 5.1e-05</acceleration>
+          <wrench>-0.063367 9.77782 9.78037 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_20'>
-        <pose>4.33732 -4.7307 0.499995 1e-05 -0 -0.006905</pose>
+        <pose>4.33732 -4.73069 0.499995 -1e-05 0 -0.006905</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>4.33732 -4.7307 0.499995 1e-05 -0 -0.006905</pose>
+          <pose>4.33732 -4.73069 0.499995 -1e-05 0 -0.006905</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>0.004717 -0.011089 -9.78157 0.022176 0.00943 -1e-06</acceleration>
-          <wrench>0.004717 -0.011089 -9.78157 0 -0 0</wrench>
+          <acceleration>-0.004717 0.011089 -9.78157 -0.022176 -0.00943 -1e-06</acceleration>
+          <wrench>-0.004717 0.011089 -9.78157 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_21'>
@@ -6632,8 +1919,8 @@
         <link name='link'>
           <pose>0.686791 -1.86676 0.499995 0 -1e-05 0.016802</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.010776 0.006185 -9.78222 -0.012437 -0.021545 3.1e-05</acceleration>
-          <wrench>-0.010776 0.006185 -9.78222 0 -0 0</wrench>
+          <acceleration>-0.010769 0.006184 -9.78223 -0.012436 -0.021533 3.1e-05</acceleration>
+          <wrench>-0.010769 0.006184 -9.78223 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_22'>
@@ -6642,8 +1929,8 @@
         <link name='link'>
           <pose>-0.31336 -1.86992 0.499995 0 1e-05 0.016914</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>0.010528 0.006187 -9.78228 -0.01237 0.021056 -3e-06</acceleration>
-          <wrench>0.010528 0.006187 -9.78228 0 -0 0</wrench>
+          <acceleration>0.010772 -0.006184 -9.78223 0.012436 0.021538 3.1e-05</acceleration>
+          <wrench>0.010772 -0.006184 -9.78223 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_23'>
@@ -6652,198 +1939,238 @@
         <link name='link'>
           <pose>-1.31367 -1.86213 0.499995 0 1e-05 0.016973</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>0.010485 0.006189 -9.78235 -0.012375 0.020971 -3e-06</acceleration>
-          <wrench>0.010485 0.006189 -9.78235 0 -0 0</wrench>
+          <acceleration>0.010715 -0.00618 -9.78232 0.012432 0.021424 3.3e-05</acceleration>
+          <wrench>0.010715 -0.00618 -9.78232 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_24'>
-        <pose>-2.33714 -1.57173 0.499995 0 -1e-05 0.008087</pose>
+        <pose>-2.32285 -1.57254 0.499995 0 -1e-05 0.001689</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>-2.33714 -1.57173 0.499995 0 -1e-05 0.008087</pose>
+          <pose>-2.32285 -1.57254 0.499995 0 -1e-05 0.001689</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.010666 0.006192 -9.78231 -0.01244 -0.021327 2.6e-05</acceleration>
-          <wrench>-0.010666 0.006192 -9.78231 0 -0 0</wrench>
-        </link>
-      </model>
-      <model name='unit_box_clone_25'>
-        <pose>-3.33819 -1.63335 0.499995 1e-05 -0 0.00575</pose>
-        <scale>1 1 1</scale>
-        <link name='link'>
-          <pose>-3.33819 -1.63335 0.499995 1e-05 -0 0.00575</pose>
-          <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.004887 -0.011285 -9.78124 0.022563 -0.00977 1e-06</acceleration>
-          <wrench>-0.004887 -0.011285 -9.78124 0 -0 0</wrench>
-        </link>
-      </model>
-      <model name='unit_box_clone_26'>
-        <pose>-3.31838 -0.606192 0.499995 -1e-05 0 -0.049829</pose>
-        <scale>1 1 1</scale>
-        <link name='link'>
-          <pose>-3.31838 -0.606192 0.499995 -1e-05 0 -0.049829</pose>
-          <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>0.004726 0.010859 -9.78153 -0.021712 0.009449 -0</acceleration>
-          <wrench>0.004726 0.010859 -9.78153 0 -0 0</wrench>
-        </link>
-      </model>
-      <model name='unit_box_clone_27'>
-        <pose>-3.25847 0.396021 0.499995 -1e-05 -0 -0.041899</pose>
-        <scale>1 1 1</scale>
-        <link name='link'>
-          <pose>-3.25847 0.396021 0.499995 -1e-05 -0 -0.041899</pose>
-          <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>0.004596 0.010734 -9.78181 -0.021466 0.009189 0</acceleration>
-          <wrench>0.004596 0.010734 -9.78181 0 -0 0</wrench>
-        </link>
-      </model>
-      <model name='unit_box_clone_28'>
-        <pose>-3.18483 1.39386 0.499995 -1e-05 -0 -0.041812</pose>
-        <scale>1 1 1</scale>
-        <link name='link'>
-          <pose>-3.18483 1.39386 0.499995 -1e-05 -0 -0.041812</pose>
-          <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>0.004596 0.010735 -9.7818 -0.021468 0.00919 0</acceleration>
-          <wrench>0.004596 0.010735 -9.7818 0 -0 0</wrench>
+          <acceleration>-0.010626 0.006191 -9.78231 -0.012427 -0.021248 2e-05</acceleration>
+          <wrench>-0.010626 0.006191 -9.78231 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_29'>
-        <pose>-2.16594 1.37501 0.499995 -0 -1e-05 -0.003205</pose>
+        <pose>-2.17385 1.3594 0.5 0 -0 0.006423</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>-2.16594 1.37501 0.499995 -0 -1e-05 -0.003205</pose>
+          <pose>-2.17385 1.3594 0.5 0 -0 0.006423</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.010592 0.006192 -9.78231 -0.012419 -0.021181 1.5e-05</acceleration>
-          <wrench>-0.010592 0.006192 -9.78231 0 -0 0</wrench>
+          <acceleration>9.77775 0.070452 9.78042 -0.140884 0.705964 5.3e-05</acceleration>
+          <wrench>9.77775 0.070452 9.78042 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_3'>
-        <pose>5.28082 -1.46799 0.5 0 -0 0.006712</pose>
+        <pose>5.27998 -1.47594 0.499995 -9e-06 -0 0.007189</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>5.28082 -1.46799 0.5 0 -0 0.006712</pose>
+          <pose>5.27998 -1.47594 0.499995 -9e-06 -0 0.007189</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>9.78171 0.071883 9.78228 -0.143792 0.713847 5.4e-05</acceleration>
-          <wrench>9.78171 0.071883 9.78228 0 -0 0</wrench>
+          <acceleration>-0.093752 0.124259 -9.59181 -0.248422 -0.189861 -0.001278</acceleration>
+          <wrench>-0.093752 0.124259 -9.59181 0 -0 0</wrench>
         </link>
       </model>
-      <model name='unit_box_clone_30_clone'>
-        <pose>0.903071 6.59349 0.499995 0 -1e-05 0.008036</pose>
+      <model name='unit_box_clone_30'>
+        <pose>2.96649 7.52749 0.499995 1e-05 0 -0.017611</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>0.903071 6.59349 0.499995 0 -1e-05 0.008036</pose>
+          <pose>2.96649 7.52749 0.499995 1e-05 0 -0.017611</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.010666 0.006192 -9.78231 -0.01244 -0.021327 2.6e-05</acceleration>
-          <wrench>-0.010666 0.006192 -9.78231 0 -0 0</wrench>
+          <acceleration>-0.004676 -0.010946 -9.78162 0.021889 -0.009348 1e-06</acceleration>
+          <wrench>-0.004676 -0.010946 -9.78162 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_30_clone_0'>
-        <pose>0.922238 4.21709 0.499995 1e-05 -0 0.008734</pose>
+        <pose>0.922238 4.2171 0.499995 -1e-05 0 0.008732</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>0.922238 4.21709 0.499995 1e-05 -0 0.008734</pose>
+          <pose>0.922238 4.2171 0.499995 -1e-05 0 0.008732</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.004719 -0.011098 -9.78157 0.022192 -0.009434 1e-06</acceleration>
-          <wrench>-0.004719 -0.011098 -9.78157 0 -0 0</wrench>
+          <acceleration>-0.004694 0.011005 -9.78159 -0.022007 -0.009386 -1e-06</acceleration>
+          <wrench>-0.004694 0.011005 -9.78159 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_31'>
-        <pose>2.90332 6.59363 0.499995 -1e-05 -0 0.007715</pose>
+        <pose>0.966476 7.56669 0.499995 -1e-05 0 -0.01713</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>2.90332 6.59363 0.499995 -1e-05 -0 0.007715</pose>
+          <pose>0.966476 7.56669 0.499995 -1e-05 0 -0.01713</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.004696 0.011012 -9.78159 -0.02202 -0.009389 -1e-06</acceleration>
-          <wrench>-0.004696 0.011012 -9.78159 0 -0 0</wrench>
+          <acceleration>0.004677 0.01095 -9.78162 -0.021896 0.009351 1e-06</acceleration>
+          <wrench>0.004677 0.01095 -9.78162 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_32'>
-        <pose>3.90388 6.52631 0.5 0 -0 0.007733</pose>
+        <pose>-0.077473 7.71365 0.5 0 -0 -0.001362</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>3.90388 6.52631 0.5 0 -0 0.007733</pose>
+          <pose>-0.077473 7.71365 0.5 0 -0 -0.001362</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>0 -0 0 1e-06 1e-06 0</acceleration>
-          <wrench>0 -0 0 0 -0 0</wrench>
+          <acceleration>-0 -0 0 1e-06 -1e-06 0</acceleration>
+          <wrench>-0 -0 0 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_33'>
-        <pose>5.2604 5.53449 0.499995 0 -1e-05 0.010478</pose>
+        <pose>5.27661 5.52628 0.499995 1e-05 -0 0.003347</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>5.2604 5.53449 0.499995 0 -1e-05 0.010478</pose>
+          <pose>5.27661 5.52628 0.499995 1e-05 -0 0.003347</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.01068 0.006194 -9.78231 -0.012449 -0.021355 2.8e-05</acceleration>
-          <wrench>-0.01068 0.006194 -9.78231 0 -0 0</wrench>
+          <acceleration>0.004704 -0.011037 -9.78158 0.022071 0.009404 -1e-06</acceleration>
+          <wrench>0.004704 -0.011037 -9.78158 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_33_clone'>
-        <pose>4.90406 6.53202 0.5 0 -0 0.008086</pose>
+        <pose>4.95423 6.53093 0.5 -0 -0 -0.008101</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>4.90406 6.53202 0.5 0 -0 0.008086</pose>
+          <pose>4.95423 6.53093 0.5 -0 -0 -0.008101</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.074386 9.78085 9.78163 -0.712136 -0.148774 -4.3e-05</acceleration>
-          <wrench>-0.074386 9.78085 9.78163 0 -0 0</wrench>
+          <acceleration>-0 0 0 -1e-06 -1e-06 0</acceleration>
+          <wrench>-0 0 0 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_34'>
-        <pose>1.9033 6.59064 0.499995 -1e-05 -0 0.007715</pose>
+        <pose>1.96534 7.48115 0.499995 0 -1e-05 -0.017355</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>1.9033 6.59064 0.499995 -1e-05 -0 0.007715</pose>
+          <pose>1.96534 7.48115 0.499995 0 -1e-05 -0.017355</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>0.004718 0.011093 -9.78157 -0.022183 0.009432 1e-06</acceleration>
-          <wrench>0.004718 0.011093 -9.78157 0 -0 0</wrench>
+          <acceleration>-0.010717 -0.00618 -9.78232 0.012431 -0.021428 -3.3e-05</acceleration>
+          <wrench>-0.010717 -0.00618 -9.78232 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_clone_35'>
+        <pose>-0.132625 4.42696 0.499995 -1e-05 -0 -0.005022</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-0.132625 4.42696 0.499995 -1e-05 -0 -0.005022</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0.004701 0.011028 -9.78158 -0.022052 0.009399 1e-06</acceleration>
+          <wrench>0.004701 0.011028 -9.78158 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_clone_36'>
+        <pose>-1.17874 4.40164 0.499995 -0 1e-05 0.01078</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-1.17874 4.40164 0.499995 -0 1e-05 0.01078</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0.010682 -0.006194 -9.78231 0.01245 0.021358 2.8e-05</acceleration>
+          <wrench>0.010682 -0.006194 -9.78231 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_clone_37'>
+        <pose>-1.26167 5.4008 0.499995 -0 1e-05 0.01078</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-1.26167 5.4008 0.499995 -0 1e-05 0.01078</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0.010682 -0.006194 -9.78231 0.01245 0.021358 2.8e-05</acceleration>
+          <wrench>0.010682 -0.006194 -9.78231 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_clone_38'>
+        <pose>-1.3794 6.39968 0.499995 -1e-05 -0 0.010935</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-1.3794 6.39968 0.499995 -1e-05 -0 0.010935</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0.00469 0.010991 -9.7816 -0.02198 -0.009377 -1e-06</acceleration>
+          <wrench>-0.00469 0.010991 -9.7816 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_clone_39'>
+        <pose>-1.07785 7.48261 0.499995 1e-05 -0 -0.001407</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-1.07785 7.48261 0.499995 1e-05 -0 -0.001407</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0.004707 -0.011048 -9.78158 0.022092 -0.00941 1e-06</acceleration>
+          <wrench>-0.004707 -0.011048 -9.78158 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_4'>
-        <pose>1.70035 -1.80405 0.499995 -0 1e-05 0.024342</pose>
+        <pose>1.70034 -1.80405 0.499995 0 -1e-05 0.024342</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>1.70035 -1.80405 0.499995 -0 1e-05 0.024342</pose>
+          <pose>1.70034 -1.80405 0.499995 0 -1e-05 0.024342</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>0.010421 0.006164 -9.78239 -0.012324 0.020844 -3e-06</acceleration>
-          <wrench>0.010421 0.006164 -9.78239 0 -0 0</wrench>
+          <acceleration>-0.01075 0.006162 -9.78234 -0.012406 -0.021493 3.8e-05</acceleration>
+          <wrench>-0.01075 0.006162 -9.78234 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_clone_40'>
+        <pose>-2.07782 7.52618 0.499995 -1e-05 -0 -0.00144</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-2.07782 7.52618 0.499995 -1e-05 -0 -0.00144</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>-0.004711 0.011063 -9.78157 -0.022123 -0.009418 -1e-06</acceleration>
+          <wrench>-0.004711 0.011063 -9.78157 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='unit_box_clone_5'>
+        <pose>4.97164 7.531 0.499995 1e-05 -0 -0.008451</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>4.97164 7.531 0.499995 1e-05 -0 -0.008451</pose>
+          <velocity>0 0 0 0 -0 0</velocity>
+          <acceleration>0.004719 -0.011096 -9.78157 0.022189 0.009433 -1e-06</acceleration>
+          <wrench>0.004719 -0.011096 -9.78157 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_6'>
-        <pose>1.92297 4.38815 0.499995 0 1e-05 0.004372</pose>
+        <pose>1.923 4.38822 0.499995 -1e-05 0 0.004295</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>1.92297 4.38815 0.499995 0 1e-05 0.004372</pose>
+          <pose>1.923 4.38822 0.499995 -1e-05 0 0.004295</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>0.010643 -0.006191 -9.78231 0.012431 0.021282 2.3e-05</acceleration>
-          <wrench>0.010643 -0.006191 -9.78231 0 -0 0</wrench>
+          <acceleration>0.004774 0.011149 -9.78145 -0.022293 0.009544 1e-06</acceleration>
+          <wrench>0.004774 0.011149 -9.78145 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_7'>
-        <pose>1.95192 3.38818 0.499995 0 -1e-05 0.004236</pose>
+        <pose>1.95193 3.38825 0.499995 1e-05 -0 0.00419</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>1.95192 3.38818 0.499995 0 -1e-05 0.004236</pose>
+          <pose>1.95193 3.38825 0.499995 1e-05 -0 0.00419</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.010642 0.006191 -9.78231 -0.012431 -0.02128 2.2e-05</acceleration>
-          <wrench>-0.010642 0.006191 -9.78231 0 -0 0</wrench>
+          <acceleration>-0.004778 -0.011153 -9.78145 0.022302 -0.009553 1e-06</acceleration>
+          <wrench>-0.004778 -0.011153 -9.78145 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_8'>
-        <pose>1.96186 2.38528 0.499995 0 -1e-05 -0.001096</pose>
+        <pose>1.96253 2.38588 0.499995 -0 -1e-05 5.1e-05</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>1.96186 2.38528 0.499995 0 -1e-05 -0.001096</pose>
+          <pose>1.96253 2.38588 0.499995 -0 -1e-05 5.1e-05</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.010607 0.006192 -9.78231 -0.012422 -0.021211 1.7e-05</acceleration>
-          <wrench>-0.010607 0.006192 -9.78231 0 -0 0</wrench>
+          <acceleration>-0.010614 -0.006192 -9.78231 0.012424 -0.021225 -1.8e-05</acceleration>
+          <wrench>-0.010614 -0.006192 -9.78231 0 -0 0</wrench>
         </link>
       </model>
       <model name='unit_box_clone_9'>
-        <pose>5.23894 3.53276 0.499995 -1e-05 0 0.007709</pose>
+        <pose>5.23699 3.52421 0.5 0 -0 0.006543</pose>
         <scale>1 1 1</scale>
         <link name='link'>
-          <pose>5.23894 3.53276 0.499995 -1e-05 0 0.007709</pose>
+          <pose>5.23699 3.52421 0.5 0 -0 0.006543</pose>
           <velocity>0 0 0 0 -0 0</velocity>
-          <acceleration>-0.004696 0.011012 -9.78159 -0.02202 -0.009389 -1e-06</acceleration>
-          <wrench>-0.004696 0.011012 -9.78159 0 -0 0</wrench>
+          <acceleration>9.78424 0.058953 9.78328 -0.117771 0.718896 -9.8e-05</acceleration>
+          <wrench>9.78424 0.058953 9.78328 0 -0 0</wrench>
+        </link>
+      </model>
+      <model name='wooden_peg'>
+        <pose>-12.7812 5.26987 0.008749 1.5708 1.32977 -1.95871</pose>
+        <scale>1 1 1</scale>
+        <link name='link'>
+          <pose>-12.8182 5.285 0.008749 1.5708 1.32977 -1.95871</pose>
+          <velocity>-0.019938 -0.048795 4e-06 1.86302 -1.09664 -3.14159</velocity>
+          <acceleration>0 -0 0 0 -0 0</acceleration>
+          <wrench>0 -0 0 0 -0 0</wrench>
         </link>
       </model>
       <light name='sun'>
@@ -6852,7 +2179,7 @@
     </state>
     <gui fullscreen='0'>
       <camera name='user_camera'>
-        <pose>6.03611 0.871005 12.8233 0 1.3458 -2.09903</pose>
+        <pose>4.45026 22.5179 31.8603 0 0.889798 -1.73104</pose>
         <view_controller>orbit</view_controller>
         <projection_type>perspective</projection_type>
       </camera>
@@ -6965,6 +2292,1821 @@
     </model>
     <model name='unit_box_clone_15_clone'>
       <pose>5.34824 -4.41181 0.5 0 -0 0.004915</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box'>
+      <pose>-1.18866 1.57916 0.5 0 -0 0</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_clone_5'>
+      <pose>4.89264 7.43427 0.499995 -1e-05 -0 -0.005022</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_clone_16'>
+      <pose>3.82931 7.4215 0.499995 -0 1e-05 -0.005022</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_clone_30'>
+      <pose>3.18475 7.51669 0.499995 0 -1e-05 -0.005022</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_clone_31'>
+      <pose>1.92761 7.40555 0.499995 0 -1e-05 -0.005022</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_clone_32'>
+      <pose>1.72019 7.292 0.5 0 0 -0.005022</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_clone_34'>
+      <pose>0.253959 5.80795 0.499995 -1e-05 -0 -0.005022</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_clone_35'>
+      <pose>-0.132625 4.42695 0.5 0 -0 -0.005022</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_clone_36'>
+      <pose>-1.18319 4.49558 0.499995 0 -1e-05 -0.005022</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_clone_37'>
+      <pose>-1.2649 5.4186 0.5 -0 -0 -0.005022</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_clone_38'>
+      <pose>-1.37215 6.28718 0.5 0 -0 -0.005022</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_clone_39'>
+      <pose>-1.13252 7.48759 0.5 0 -0 -0.005022</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_clone_40'>
+      <pose>-2 7.5243 0.499995 -0 1e-05 -0.005022</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <max_contacts>10</max_contacts>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='wooden_peg'>
+      <link name='link'>
+        <pose>0 0 0.04 0 -0 0</pose>
+        <inertial>
+          <mass>0.0175</mass>
+          <inertia>
+            <ixx>9.74923e-06</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>9.74923e-06</iyy>
+            <iyz>0</iyz>
+            <izz>8.31797e-07</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <cylinder>
+              <radius>0.00975</radius>
+              <length>0.08</length>
+            </cylinder>
+          </geometry>
+          <surface>
+            <contact>
+              <poissons_ratio>0.347</poissons_ratio>
+              <elastic_modulus>8.8e+09</elastic_modulus>
+              <ode>
+                <kp>100000</kp>
+                <kd>100</kd>
+                <max_vel>100</max_vel>
+                <min_depth>0.001</min_depth>
+              </ode>
+            </contact>
+            <friction>
+              <torsional>
+                <coefficient>1</coefficient>
+                <use_patch_radius>0</use_patch_radius>
+                <surface_radius>0.01</surface_radius>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+            <bounce/>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <cylinder>
+              <radius>0.00975</radius>
+              <length>0.08</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Wood</name>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+      <pose>-3.30533 1.48502 0 0 -0 0</pose>
+    </model>
+    <model name='unit_box_0_clone'>
+      <pose>-4.36191 -1.6897 0.499995 1e-05 -0 0</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_0'>
+      <pose>-4.24923 -2.66454 0.499995 1e-05 -0 0</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_1'>
+      <pose>-4.26778 -3.58837 0.499995 1e-05 -0 0</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_2'>
+      <pose>-5.38649 -3.69388 0.499995 1e-05 -0 0</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_3'>
+      <pose>-6.42835 -3.64013 0.499995 1e-05 -0 0</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_4'>
+      <pose>-7.50084 -3.52544 0.499995 1e-05 -0 0</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_5'>
+      <pose>-3.20183 1.32209 0.499995 1e-05 -0 0</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_6'>
+      <pose>-4.08564 1.3432 0.499995 1e-05 -0 0</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_clone'>
+      <pose>-3.31214 -1.53778 0.5 0 -0 0.000193</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_clone_0'>
+      <pose>-4.192 2.3708 0.5 0 -0 0.000193</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_clone_2'>
+      <pose>-6.38533 2.27205 0.5 0 -0 0.000193</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_clone_3'>
+      <pose>-7.32524 2.37597 0.5 0 -0 0.000193</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_clone_4'>
+      <pose>-8.53915 2.33033 0.5 0 -0 0.000193</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_clone_6'>
+      <pose>-5.22937 2.22706 0.5 0 -0 0.000193</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_clone_1'>
+      <pose>-8.34958 -3.4385 0.5 0 -0 0.000193</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_clone_5'>
+      <pose>-8.47558 -2.45557 0.499995 -1e-05 -0 0.000193</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_clone_7'>
+      <pose>-8.56136 -1.44999 0.499995 0 1e-05 0.000193</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_clone_8'>
+      <pose>-8.55418 -0.594154 0.5 0 -0 0.000193</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_clone_9'>
+      <pose>-8.34759 0.539681 0.499995 0 -1e-05 0.000193</pose>
+      <link name='link'>
+        <inertial>
+          <mass>1</mass>
+          <inertia>
+            <ixx>0.166667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.166667</iyy>
+            <iyz>0</iyz>
+            <izz>0.166667</izz>
+          </inertia>
+          <pose>0 0 0 0 -0 0</pose>
+        </inertial>
+        <collision name='collision'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <surface>
+            <contact>
+              <ode/>
+            </contact>
+            <bounce/>
+            <friction>
+              <torsional>
+                <ode/>
+              </torsional>
+              <ode/>
+            </friction>
+          </surface>
+          <max_contacts>10</max_contacts>
+        </collision>
+        <visual name='visual'>
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+          <material>
+            <script>
+              <name>Gazebo/Grey</name>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+            </script>
+          </material>
+        </visual>
+        <self_collide>0</self_collide>
+        <enable_wind>0</enable_wind>
+        <kinematic>0</kinematic>
+      </link>
+    </model>
+    <model name='unit_box_0_clone_clone_10'>
+      <pose>-8.35038 1.32231 0.499995 0 -1e-05 0.000193</pose>
       <link name='link'>
         <inertial>
           <mass>1</mass>

--- a/tmb_perception/src/target_distance_detector
+++ b/tmb_perception/src/target_distance_detector
@@ -3,6 +3,18 @@
 import rospy
 import rospkg
 import numpy as np
+import os
+
+# Set environment variables
+os.environ['API_USER'] = 'username'
+os.environ['API_PASSWORD'] = 'secret'
+
+# Get environment variables
+USER = os.getenv('API_USER')
+PASSWORD = os.environ.get('API_PASSWORD')
+
+# Getting non-existent keys
+FOO = os.getenv('FOO') # None
 
 from geometry_msgs.msg import Point, Pose, Quaternion
 from std_msgs.msg import Bool, String, Int8
@@ -27,6 +39,9 @@ class DistanceDetector:
         self.blind_robot_position = np.array([4, -3.5])
         self.latest_data = Object_Sighted()
         self.object_detected=True
+        goal_x = os.getenv('tmb_start_goal_x')
+        goal_y = os.getenv('tmb_start_goal_y')
+        self.goal_position=np.array([float(goal_x), float(goal_y)])
 
     def get_blind_robot(self, point):
         self.blind_robot_position = np.array([point.x, point.y])
@@ -45,33 +60,36 @@ class DistanceDetector:
             # in order to account for occlusion the coordinate frame is
             # translated forward in the direction that the robot is facing.
             moved_position = position + 0.6*normalized_bearing;
-            # relative position vector to the blind robot
-            robot_to_blind = self.blind_robot_position - moved_position
-            total_distance = np.linalg.norm(robot_to_blind)
-            norm_robot_to_blind = normalize(robot_to_blind)
-            # value between -1 and 1, where 1 is facing exactly at the blind, -1 is facing opposite.
-            incidence = np.dot(norm_robot_to_blind, normalized_bearing)
-            leaning = "right" if np.cross(normalized_bearing, norm_robot_to_blind) > 0 else "left"
-            object_detected = "robot_detected"
-            if False:
-                print('------------------------------------------')
-                print("pose received for robot:", robot)
-                print('distance to blind', total_distance)
-                print('pose', pose)
-                print('angle_to_target', incidence)
-                print('------------------------------------------')
-            # todo add case for objects obstructing the view.
-            self.latest_data.detected_by=robot
+            # relative position vector to the obstacle
+            for index, obstacle in enumerate([self.goal_position, self.blind_robot_position]):
+                robot_to_obstacle = obstacle - moved_position
+                total_distance = np.linalg.norm(robot_to_obstacle)
+                norm_robot_to_obstacle= normalize(robot_to_obstacle)
+                # value between -1 and 1, where 1 is facing exactly at the blind, -1 is facing opposite.
+                incidence = np.dot(norm_robot_to_obstacle, normalized_bearing)
+                leaning = "right" if np.cross(normalized_bearing, norm_robot_to_obstacle) > 0 else "left"
+                object_name = "goal" if index == 0 else "blind_robot"
 
-            if total_distance < 2 and total_distance > 0.6 and incidence > 0.6:
-                self.latest_data.object_detected="robot_blind"
-                self.latest_data.object_position_estimate=Point(self.blind_robot_position[0], self.blind_robot_position[1], 0)
-                self.latest_data.object_to_the_left_or_right=leaning
-                self.latest_data.distance=total_distance
-                self.latest_data.incidence=incidence
-                self.object_detected = True
-            else:
-                self.object_detected = False
+                if os.getenv('tmb_publish_perception_logs') == True:
+                    print('------------------------------------------')
+                    print("regarding object:", object_name)
+                    print("pose received for robot:", robot)
+                    print('distance to target', total_distance)
+                    print('robot pose (x, y)', (pose.x, pose.y))
+                    print('incidence', incidence)
+                    print('------------------------------------------')
+                # todo add case for objects obstructing the view.
+                self.latest_data.detected_by=robot
+
+                if total_distance < 2 and total_distance > 0.6 and incidence > 0.6:
+                    self.latest_data.object_detected= object_name
+                    self.latest_data.object_position_estimate=Point(obstacle[0], obstacle[1], 0)
+                    self.latest_data.object_to_the_left_or_right=leaning
+                    self.latest_data.distance=total_distance
+                    self.latest_data.incidence=incidence
+                    self.object_detected = True
+                else:
+                    self.object_detected = False
         return get_pose_func
 
     def send_data(self, data):
@@ -87,5 +105,5 @@ class DistanceDetector:
 if __name__ == "__main__":
     rospy.init_node('target_distance_detector')
     target_distance_detector = DistanceDetector()
-    rospy.Timer(rospy.Duration(1.0/100.0), target_distance_detector.send_data)
+    rospy.Timer(rospy.Duration(1.0/1.0), target_distance_detector.send_data)
     target_distance_detector.run()

--- a/tmb_startup/launch/complete_launch.launch
+++ b/tmb_startup/launch/complete_launch.launch
@@ -2,11 +2,11 @@
     <include file="$(find tmb_startup)/launch/robots_start.launch"/>
     <include file="$(find tmb_communication)/launch/robot_nodes.launch">
       <arg name="robot_name" value="robot1" />
-      <arg name="node_start_delay" value="5.0" /> 
+      <arg name="node_start_delay" value="5.0" />
     </include>
-    <include file="$(find tmb_communication)/launch/robot_nodes.launch">
+    <include file="$(find tmb_communication)/launch/robot_nodes.launch" if="$(env tmb_start_both)">
       <arg name="robot_name" value="robot2" />
-      <arg name="node_start_delay" value="8.0" /> 
+      <arg name="node_start_delay" value="8.0" />
     </include>
     <include file="$(find tmb_communication)/launch/multi_map_merge.launch"/>
     <node type="rviz" name="rviz" pkg="rviz" args="-d $(find tmb_communication)/config/rviz_basic_setup.rviz"/>

--- a/tmb_startup/launch/robots_start.launch
+++ b/tmb_startup/launch/robots_start.launch
@@ -14,6 +14,7 @@
     <param name="robot_description" command="$(find xacro)/xacro --inorder $(find tmb_models)/urdf/robots/$(arg robot).urdf.xacro"/>
     <param name="robot_blind_description" command="$(find xacro)/xacro --inorder $(find tmb_models)/urdf/robots/$(arg robot_blind).urdf.xacro"/>
 
+
     <group ns="robot1">
         <param name="tf_prefix" value="robot1"/>
         <arg name="name" default="robot1" />
@@ -33,7 +34,7 @@
             <param name="name" type="str" value="robot1"/>
         </node>
     </group>
-    <group ns="robot2">
+    <group ns="robot2" if="$(env tmb_start_both)">
         <param name="tf_prefix" value="robot2"/>
         <arg name="name"  value="robot2"/>
         <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen">
@@ -66,9 +67,16 @@
           -z $(env tmb_start_robot_blind_z)
           -Y $(env tmb_start_robot_blind_yaw)
           -param /robot_blind_description" />
-
         <node pkg="tmb_communication" type="gazebo_position_listener" name="gazebo_pos_listener" output="screen" >
             <param name="name" type="str" value="robot_blind"/>
         </node>
+    </group>
+    <group ns="goal">
+      <node name="goal_spawn_urdf" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen"
+        args="-file $(find tmb_models)/objects/Goal/model.sdf -sdf
+        -x $(env tmb_start_goal_x)
+        -y $(env tmb_start_goal_y)
+        -Y $(env tmb_start_goal_yaw)
+        -model goal_cube"/>
     </group>
 </launch>


### PR DESCRIPTION
As promised I've made some updates to so the target_distance_detector also picks up the goal.
Included is:
the ability to choose to only start one robot "tmb_start_both=[True, False]"
the fact that the goal is now dynamically placed into each world with 
" export tmb_start_goal_x="0.60339"
  export tmb_start_goal_y="6.06"
  export tmb_start_goal_yaw="0""
btw, if you run the simulator with just the robots roslaunch tmb_startup robots_start.launch the detector still works.
So you can move the robot around in gazebo and get the expected target_distance_detector node output.
I've also added additional logs if needed, they can be toggled on/off with tmb_publish_perception_logs=[True, False]


@parsaw100 @kemme5 